### PR TITLE
ONB-517: Row spacing card form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- `ComposableContainer` no longer applies `fieldSpacing` (row spacing) above the first row or below the last row of the card form. The first row now pins flush to the parent top, and the parent bottom uses a small 5pt padding below the last error label instead of `rowSpacing`. Merchants previously compensating with negative `wrapperStyle.padding` insets can remove that workaround. (ONB-517)
+
 ## [1.27.0] - 2026-04-08
 
 ### Added

--- a/Payrails/Classes/Public/Vault/composable/ComposableContainer.swift
+++ b/Payrails/Classes/Public/Vault/composable/ComposableContainer.swift
@@ -206,7 +206,11 @@ public extension Container {
             }
 
             childView.translatesAutoresizingMaskIntoConstraints = false
-            childView.topAnchor.constraint(equalTo: previousLabel?.bottomAnchor ?? previousChildView?.bottomAnchor ?? parentView.topAnchor, constant: rowSpacing).isActive = true
+            // rowSpacing applies only between sibling rows, not above the first row.
+            // The first row pins flush to parentView.topAnchor (ONB-517).
+            let isFirstRow = (previousLabel == nil && previousChildView == nil)
+            let topAnchorTarget = previousLabel?.bottomAnchor ?? previousChildView?.bottomAnchor ?? parentView.topAnchor
+            childView.topAnchor.constraint(equalTo: topAnchorTarget, constant: isFirstRow ? 0 : rowSpacing).isActive = true
             childView.leadingAnchor.constraint(equalTo: parentView.leadingAnchor).isActive = true
             childView.trailingAnchor.constraint(equalTo: parentView.trailingAnchor).isActive = true
 
@@ -222,7 +226,8 @@ public extension Container {
             previousLabel = labelArray[i]
         }
         previousChildView?.trailingAnchor.constraint(equalTo: parentView.trailingAnchor).isActive = true
-        parentView.bottomAnchor.constraint(equalTo: previousLabel?.bottomAnchor ?? previousChildView?.bottomAnchor ?? parentView.bottomAnchor, constant: rowSpacing).isActive = true
+        // Keep a small padding below the last error label for breathing room; do not use rowSpacing here (ONB-517).
+        parentView.bottomAnchor.constraint(equalTo: previousLabel?.bottomAnchor ?? previousChildView?.bottomAnchor ?? parentView.bottomAnchor, constant: 5.0).isActive = true
 
         return parentView
     }

--- a/PayrailsTests/PayrailsTests.swift
+++ b/PayrailsTests/PayrailsTests.swift
@@ -295,6 +295,176 @@ final class PayrailsTests: XCTestCase {
         )
     }
 
+    // MARK: - ONB-517: rowSpacing must not apply at form edges
+
+    func testComposableContainerFirstRowPinsFlushToParentTop() throws {
+        let client = Client()
+        let options = ContainerOptions(layout: [1, 1])
+
+        guard let container = client.container(type: ContainerType.COMPOSABLE, options: options) else {
+            XCTFail("Expected composable container")
+            return
+        }
+        container.composableRowSpacing = 24
+
+        let cardNumberInput = CollectElementInput(
+            table: "cards", column: "card_number",
+            label: "Card number", placeholder: "Card number", type: .CARD_NUMBER
+        )
+        let cvvInput = CollectElementInput(
+            table: "cards", column: "security_code",
+            label: "CVV", placeholder: "CVV", type: .CVV
+        )
+        _ = container.create(input: cardNumberInput, options: CollectElementOptions(required: true))
+        _ = container.create(input: cvvInput, options: CollectElementOptions(required: true))
+
+        let composableView = try container.getComposableView()
+        let rowViews = composableView.subviews.filter { view in
+            view.subviews.contains(where: { $0 is TextField })
+        }
+        guard let firstRow = rowViews.first else {
+            XCTFail("Expected at least one row view")
+            return
+        }
+
+        let firstRowTop = constraintConstant(
+            in: composableView.constraints,
+            firstItem: firstRow,
+            firstAttribute: .top,
+            secondItem: composableView,
+            secondAttribute: .top
+        )
+        XCTAssertEqual(
+            firstRowTop ?? .nan, 0, accuracy: 0.001,
+            "First row must pin flush to parent top (no rowSpacing offset). ONB-517."
+        )
+    }
+
+    func testComposableContainerInterRowGapEqualsRowSpacing() throws {
+        let client = Client()
+        let options = ContainerOptions(layout: [1, 1])
+
+        guard let container = client.container(type: ContainerType.COMPOSABLE, options: options) else {
+            XCTFail("Expected composable container")
+            return
+        }
+        container.composableRowSpacing = 24
+
+        let cardNumberInput = CollectElementInput(
+            table: "cards", column: "card_number",
+            label: "Card number", placeholder: "Card number", type: .CARD_NUMBER
+        )
+        let cvvInput = CollectElementInput(
+            table: "cards", column: "security_code",
+            label: "CVV", placeholder: "CVV", type: .CVV
+        )
+        _ = container.create(input: cardNumberInput, options: CollectElementOptions(required: true))
+        _ = container.create(input: cvvInput, options: CollectElementOptions(required: true))
+
+        let composableView = try container.getComposableView()
+        let labelViews = composableView.subviews.compactMap { $0 as? UILabel }
+        let rowViews = composableView.subviews.filter { view in
+            view.subviews.contains(where: { $0 is TextField })
+        }
+
+        // Second row's top should be anchored to the previous row's label bottom with rowSpacing.
+        XCTAssertGreaterThanOrEqual(rowViews.count, 2, "Expected at least two row views")
+        XCTAssertGreaterThanOrEqual(labelViews.count, 1, "Expected at least one error label")
+
+        let interRowConstraint = composableView.constraints.first { c in
+            guard (c.firstItem as? UIView) === rowViews[1] else { return false }
+            guard c.firstAttribute == .top else { return false }
+            return (c.secondItem as? UIView) === labelViews[0] && c.secondAttribute == .bottom
+        }
+        XCTAssertNotNil(interRowConstraint, "Expected row 2 top anchored to row 1 label bottom")
+        XCTAssertEqual(
+            interRowConstraint?.constant ?? .nan, 24, accuracy: 0.001,
+            "Gap between sibling rows should equal configured rowSpacing."
+        )
+    }
+
+    func testComposableContainerLastRowBottomUsesSmallPaddingNotRowSpacing() throws {
+        let client = Client()
+        let options = ContainerOptions(layout: [1, 1])
+
+        guard let container = client.container(type: ContainerType.COMPOSABLE, options: options) else {
+            XCTFail("Expected composable container")
+            return
+        }
+        container.composableRowSpacing = 24
+
+        let cardNumberInput = CollectElementInput(
+            table: "cards", column: "card_number",
+            label: "Card number", placeholder: "Card number", type: .CARD_NUMBER
+        )
+        let cvvInput = CollectElementInput(
+            table: "cards", column: "security_code",
+            label: "CVV", placeholder: "CVV", type: .CVV
+        )
+        _ = container.create(input: cardNumberInput, options: CollectElementOptions(required: true))
+        _ = container.create(input: cvvInput, options: CollectElementOptions(required: true))
+
+        let composableView = try container.getComposableView()
+        let labelViews = composableView.subviews.compactMap { $0 as? UILabel }
+        guard let lastLabel = labelViews.last else {
+            XCTFail("Expected at least one error label")
+            return
+        }
+
+        let parentBottom = composableView.constraints.first { c in
+            guard (c.firstItem as? UIView) === composableView else { return false }
+            guard c.firstAttribute == .bottom else { return false }
+            return (c.secondItem as? UIView) === lastLabel && c.secondAttribute == .bottom
+        }
+        XCTAssertNotNil(parentBottom, "Expected parent bottom anchored to last error label bottom")
+        XCTAssertEqual(
+            parentBottom?.constant ?? .nan, 5.0, accuracy: 0.001,
+            "Parent bottom must use a small padding (5pt), not rowSpacing. ONB-517."
+        )
+    }
+
+    func testComposableContainerSingleRowHasNoEdgeRowSpacing() throws {
+        let client = Client()
+        let options = ContainerOptions(layout: [1])
+
+        guard let container = client.container(type: ContainerType.COMPOSABLE, options: options) else {
+            XCTFail("Expected composable container")
+            return
+        }
+        container.composableRowSpacing = 40
+
+        let cardNumberInput = CollectElementInput(
+            table: "cards", column: "card_number",
+            label: "Card number", placeholder: "Card number", type: .CARD_NUMBER
+        )
+        _ = container.create(input: cardNumberInput, options: CollectElementOptions(required: true))
+
+        let composableView = try container.getComposableView()
+        guard let rowView = composableView.subviews.first(where: { $0.subviews.contains(where: { $0 is TextField }) }) else {
+            XCTFail("Expected row view")
+            return
+        }
+
+        let topGap = constraintConstant(
+            in: composableView.constraints,
+            firstItem: rowView,
+            firstAttribute: .top,
+            secondItem: composableView,
+            secondAttribute: .top
+        )
+        XCTAssertEqual(
+            topGap ?? .nan, 0, accuracy: 0.001,
+            "Single-row layout must pin flush to parent top regardless of rowSpacing. ONB-517."
+        )
+
+        // Parent bottom should use the small padding (5pt), not the configured 40pt rowSpacing.
+        let constants = composableView.constraints.map(\.constant)
+        XCTAssertFalse(
+            constants.contains(where: { abs($0 - 40) < 0.001 }),
+            "Single-row layout must not include rowSpacing as an edge offset. ONB-517."
+        )
+    }
+
     func testComposableContainerUsesConfiguredHorizontalPaddingForFieldsAndLabels() throws {
         let client = Client()
         let insets = UIEdgeInsets(top: 0, left: 18, bottom: 0, right: 14)


### PR DESCRIPTION
## Description

## Summary

- Fixes `ComposableContainer` applying `fieldSpacing` (row spacing) above the first row and below the last row of the card form, which created unintended edge gaps in addition to the intended inter-row spacing.
- First row now pins flush to `parentView.topAnchor` (no `rowSpacing` offset).
- Parent bottom uses a small 5pt padding below the last error label for breathing room, instead of `rowSpacing`.
- Inter-row spacing continues to use `rowSpacing` exactly as before.

Addresses merchant feedback — merchants previously working around this with negative `wrapperStyle.padding` insets can remove that workaround.
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Release
- [ ] ⏩ Revert

## Screenshots/Recordings

<!-- Visual changes require screenshots -->

## Added tests?

- [x] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?

- [ ] 📜 README.md
- [ ] 🗂️ Internal documentation
- [ ] 📓 Public Documentation (docs.payrails.com)
- [ ] 🙅 no documentation needed

## [optional] Are there any post-release tasks we need to perform?
