### PR TITLE
ONB-521: Unblock black-lane integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- `Payrails.Session` methods are now public: `executePayment(...)` (all variants), `deleteInstrument(instrumentId:)`, `updateInstrument(instrumentId:body:)`, `query(_:)`, `storedInstruments(for:)`, `isApplePayAvailable`, `isPaymentAvailable(type:)`, `isPaymentCodeAvailable(paymentMethodCode:)`, `cancelPayment()`, and `update(_:)`. Headless merchants can now drive the full payment lifecycle and instrument management from their own UI with compile-time safety.
+- `Payrails.Session` methods are now public: `executePayment(...)` (all variants), `deleteInstrument(instrumentId:)`, `updateInstrument(instrumentId:body:)`, `query(_:)`, `storedInstruments(for:)`, `isApplePayAvailable`, `cancelPayment()`, and `update(_:)`. Headless merchants can now drive the full payment lifecycle and instrument management from their own UI with compile-time safety.
 
 ### Changed
 - `Session.isApplePayAvailable` now also verifies device capability via `PKPaymentAuthorizationController.canMakePayments(usingNetworks:)`, combining the backend configuration check with the device check into a single reliable `Bool`. Callers no longer need to layer a PassKit check on top.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `Payrails.Session` methods are now public: `executePayment(...)` (all variants), `deleteInstrument(instrumentId:)`, `updateInstrument(instrumentId:body:)`, `query(_:)`, `storedInstruments(for:)`, `isApplePayAvailable`, `isPaymentAvailable(type:)`, `isPaymentCodeAvailable(paymentMethodCode:)`, `cancelPayment()`, and `update(_:)`. Headless merchants can now drive the full payment lifecycle and instrument management from their own UI with compile-time safety.
+
+### Changed
+- `Session.isApplePayAvailable` now also verifies device capability via `PKPaymentAuthorizationController.canMakePayments(usingNetworks:)`, combining the backend configuration check with the device check into a single reliable `Bool`. Callers no longer need to layer a PassKit check on top.
+
+### Removed
+- `Payrails.api(_:_:_:)` and the `InstrumentAPIResponse` enum have been removed. Use the typed session methods `session.deleteInstrument(instrumentId:)` and `session.updateInstrument(instrumentId:body:)` instead. They return `DeleteInstrumentResponse` and `UpdateInstrumentResponse` directly, with compile-time safety against typos and internal renames.
+
+> ⚠️ **Breaking change:** Callers of `Payrails.api("deleteInstrument", ...)` / `Payrails.api("updateInstrument", ...)` must migrate to the session methods. See the README for the new pattern.
+
 ### Fixed
 - `ComposableContainer` no longer applies `fieldSpacing` (row spacing) above the first row or below the last row of the card form. The first row now pins flush to the parent top, and the parent bottom uses a small 5pt padding below the last error label instead of `rowSpacing`. Merchants previously compensating with negative `wrapperStyle.padding` insets can remove that workaround. (ONB-517)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- `Payrails.Session` methods are now public: `executePayment(...)` (all variants), `deleteInstrument(instrumentId:)`, `updateInstrument(instrumentId:body:)`, `query(_:)`, `storedInstruments(for:)`, `isApplePayAvailable`, `cancelPayment()`, and `update(_:)`. Headless merchants can now drive the full payment lifecycle and instrument management from their own UI with compile-time safety.
+- `Payrails.Session` methods are now public: `executePayment(...)` (all variants), `deleteInstrument(instrumentId:)`, `updateInstrument(instrumentId:body:)`, `query(_:)`, `isApplePayAvailable`, and `update(_:)`. Headless merchants can now drive the full payment lifecycle and instrument management from their own UI with compile-time safety. Session data reads (stored instruments, payment method config, amount, execution id, etc.) go through `session.query(_:)` as the single read accessor — matches the Android SDK convention.
 
 ### Changed
 - `Session.isApplePayAvailable` now also verifies device capability via `PKPaymentAuthorizationController.canMakePayments(usingNetworks:)`, combining the backend configuration check with the device check into a single reliable `Bool`. Callers no longer need to layer a PassKit check on top.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - `Payrails.Session` methods are now public: `executePayment(...)` (all variants), `deleteInstrument(instrumentId:)`, `updateInstrument(instrumentId:body:)`, `query(_:)`, `isApplePayAvailable`, and `update(_:)`. Headless merchants can now drive the full payment lifecycle and instrument management from their own UI with compile-time safety. Session data reads (stored instruments, payment method config, amount, execution id, etc.) go through `session.query(_:)` as the single read accessor — matches the Android SDK convention.
+- `session.getPaymentMethodConfig(_:)` — typed getter returning `[PayrailsPaymentOption]` filtered by `.all`, `.redirect`, or `.specific(code)`. Mirrors the web SDK's `getPaymentMethodConfig(paymentMethod)` API.
 
 ### Changed
-- `Session.isApplePayAvailable` now also verifies device capability via `PKPaymentAuthorizationController.canMakePayments(usingNetworks:)`, combining the backend configuration check with the device check into a single reliable `Bool`. Callers no longer need to layer a PassKit check on top.
+- `Session.isApplePayAvailable` is now a pure device-capability check (`PKPaymentAuthorizationController.canMakePayments()`), matching the web SDK. It no longer inspects the session configuration. For the combined "configured and device capable" signal, compose: `session.isApplePayAvailable && !session.getPaymentMethodConfig(.specific("apple_pay")).isEmpty`.
+
+> ⚠️ **Behaviour change:** `isApplePayAvailable` now returns `true` on any Apple-Pay-capable device regardless of whether Apple Pay is configured for the session. Merchants previously relying on the property as a combined check must explicitly verify configuration via `getPaymentMethodConfig(.specific("apple_pay"))`.
 
 ### Removed
 - `Payrails.api(_:_:_:)` and the `InstrumentAPIResponse` enum have been removed. Use the typed session methods `session.deleteInstrument(instrumentId:)` and `session.updateInstrument(instrumentId:body:)` instead. They return `DeleteInstrumentResponse` and `UpdateInstrumentResponse` directly, with compile-time safety against typos and internal renames.
+- Internal-only `Session.isPaymentAvailable(type:)` and `Session.isPaymentCodeAvailable(paymentMethodCode:)` have been deleted. Both were unreachable from merchant code (internal access, no external callers) and had zero internal callers. Use `session.getPaymentMethodConfig(.specific(code))` or `session.query(.paymentMethodConfig(...))` instead.
 
 > ⚠️ **Breaking change:** Callers of `Payrails.api("deleteInstrument", ...)` / `Payrails.api("updateInstrument", ...)` must migrate to the session methods. See the README for the new pattern.
 

--- a/Payrails/Classes/Public/Domains/PaymentFlow.swift
+++ b/Payrails/Classes/Public/Domains/PaymentFlow.swift
@@ -87,12 +87,6 @@ public struct UpdateInstrumentResponse: Decodable {
     }
 }
 
-public enum InstrumentAPIResponse {
-    case delete(DeleteInstrumentResponse)
-    case update(UpdateInstrumentResponse)
-    case save(SaveInstrumentResponse)
-}
-
 // MARK: - Tokenize / Save Instrument
 
 public enum FutureUsage: String, Encodable {

--- a/Payrails/Classes/Public/Payrails.swift
+++ b/Payrails/Classes/Public/Payrails.swift
@@ -239,26 +239,6 @@ public extension Payrails {
         return storedInstruments
     }
 
-    public static func api(_ operation: String, _ instrumentId: String, _ body: UpdateInstrumentBody? = nil) async throws -> InstrumentAPIResponse {
-        guard let currentSession = getCurrentSession() else {
-            throw PayrailsError.missingData("No active Payrails session. Please initialize a session first.")
-        }
-
-        switch operation {
-        case "deleteInstrument":
-            let response = try await currentSession.deleteInstrument(instrumentId: instrumentId)
-            return .delete(response)
-        case "updateInstrument":
-            guard let body = body else {
-                throw PayrailsError.missingData("UpdateInstrumentBody is required for updateInstrument operation")
-            }
-            let response = try await currentSession.updateInstrument(instrumentId: instrumentId, body: body)
-            return .update(response)
-        default:
-            throw PayrailsError.invalidDataFormat
-        }
-    }
-
     static func getStoredInstruments() -> [StoredInstrument] {
         guard let currentSession = getCurrentSession() else {
             Payrails.log("No active Payrails session available for getting stored instruments")

--- a/Payrails/Classes/Public/PayrailsSession.swift
+++ b/Payrails/Classes/Public/PayrailsSession.swift
@@ -543,6 +543,36 @@ extension Payrails.Session {
         return try await payrailsAPI.saveInstrument(body: body)
     }
 
+    // MARK: - Payment method configuration
+
+    /// Returns configuration for payment methods matching the given filter.
+    ///
+    /// Mirrors the web SDK's `getPaymentMethodConfig(paymentMethod)` API
+    /// (`web-sdk/packages/web-sdk/src/sdk/headless/query/payment-methods.ts`).
+    ///
+    /// - Parameter filter:
+    ///   - `.all` (default) returns every configured payment method.
+    ///   - `.redirect` returns only methods with a redirect client flow.
+    ///   - `.specific(code)` returns the method matching the given
+    ///     `paymentMethodCode` — a single-element array, or empty if the code
+    ///     is not configured.
+    /// - Returns: an array of `PayrailsPaymentOption`. Empty when nothing matches.
+    public func getPaymentMethodConfig(_ filter: PaymentMethodFilter = .all) -> [PayrailsPaymentOption] {
+        guard let config = config else { return [] }
+        let all = config.allPaymentOptions()
+        switch filter {
+        case .all:
+            return all.map(PayrailsPaymentOption.init)
+        case .redirect:
+            return all
+                .filter { $0.clientConfig?.flow == "redirect" }
+                .map(PayrailsPaymentOption.init)
+        case .specific(let code):
+            guard let match = all.first(where: { $0.paymentMethodCode == code }) else { return [] }
+            return [PayrailsPaymentOption(from: match)]
+        }
+    }
+
     // MARK: - Query
 
     /// Read-only access to SDK configuration and session state.

--- a/Payrails/Classes/Public/PayrailsSession.swift
+++ b/Payrails/Classes/Public/PayrailsSession.swift
@@ -89,7 +89,7 @@ public extension Payrails {
             storedInstruments(for: .payPal)
         }
 
-        func executePayment(
+        public func executePayment(
             withStoredInstrument instrument: StoredInstrument,
             presenter: PaymentPresenter? = nil,
             onResult: @escaping OnPayCallback
@@ -130,7 +130,7 @@ public extension Payrails {
             }
         }
 
-        func executePayment(
+        public func executePayment(
             with type: PaymentType,
             paymentMethodCode: String? = nil,
             saveInstrument: Bool = false,
@@ -440,7 +440,7 @@ extension Payrails.Session: PaymentHandlerDelegate {
     }
 }
 
-extension Payrails.Session {
+public extension Payrails.Session {
     @MainActor
     func executePayment(
         with type: Payrails.PaymentType,

--- a/Payrails/Classes/Public/PayrailsSession.swift
+++ b/Payrails/Classes/Public/PayrailsSession.swift
@@ -60,7 +60,7 @@ public extension Payrails {
             return config.paymentOption(forPaymentMethodCode: paymentMethodCode) != nil
         }
 
-        public func storedInstruments(for type: Payrails.PaymentType) -> [StoredInstrument] {
+        func storedInstruments(for type: Payrails.PaymentType) -> [StoredInstrument] {
             guard let paymentInstruments = config.paymentOption(for: type, extra: {
                 guard let paymentInstruments = $0.paymentInstruments else { return false }
                 switch paymentInstruments {
@@ -168,7 +168,7 @@ public extension Payrails {
             paymentHandler.makePayment(total: total, currency: config.amount.currency, presenter: presenter)
         }
 
-        public func cancelPayment() {
+        func cancelPayment() {
             isPaymentInProgress = false
             currentTask?.cancel()
             currentTask = nil

--- a/Payrails/Classes/Public/PayrailsSession.swift
+++ b/Payrails/Classes/Public/PayrailsSession.swift
@@ -41,7 +41,7 @@ public extension Payrails {
             }
         }
 
-        public func isPaymentAvailable(type: PaymentType) -> Bool {
+        func isPaymentAvailable(type: PaymentType) -> Bool {
             return config.paymentOption(for: type) != nil
         }
 
@@ -56,7 +56,7 @@ public extension Payrails {
             return PKPaymentAuthorizationController.canMakePayments(usingNetworks: pkNetworks)
         }
 
-        public func isPaymentCodeAvailable(paymentMethodCode: String) -> Bool {
+        func isPaymentCodeAvailable(paymentMethodCode: String) -> Bool {
             return config.paymentOption(forPaymentMethodCode: paymentMethodCode) != nil
         }
 

--- a/Payrails/Classes/Public/PayrailsSession.swift
+++ b/Payrails/Classes/Public/PayrailsSession.swift
@@ -45,8 +45,15 @@ public extension Payrails {
             return config.paymentOption(for: type) != nil
         }
 
-        var isApplePayAvailable: Bool {
-            return config.paymentOption(for: .applePay) != nil
+        public var isApplePayAvailable: Bool {
+            guard let option = config.paymentOption(for: .applePay),
+                  case let .applePay(applePayConfig) = option.config else {
+                return false
+            }
+            let pkNetworks = applePayConfig.parameters.supportedNetworks
+                .compactMap { PKPaymentNetwork(rawValue: $0) }
+            guard !pkNetworks.isEmpty else { return false }
+            return PKPaymentAuthorizationController.canMakePayments(usingNetworks: pkNetworks)
         }
 
         public func isPaymentCodeAvailable(paymentMethodCode: String) -> Bool {

--- a/Payrails/Classes/Public/PayrailsSession.swift
+++ b/Payrails/Classes/Public/PayrailsSession.swift
@@ -45,15 +45,22 @@ public extension Payrails {
             return config.paymentOption(for: type) != nil
         }
 
+        /// Returns `true` if the device supports Apple Pay at the platform level.
+        ///
+        /// This is a pure device-capability check (backed by
+        /// `PKPaymentAuthorizationController.canMakePayments()`). It does NOT check
+        /// whether Apple Pay is configured for this session — that's a separate
+        /// concern answered by `getPaymentMethodConfig(_:)`.
+        ///
+        /// Mirrors the web SDK's `isApplePayAvailable()`.
+        ///
+        /// For the combined "configured and device capable" signal, compose:
+        /// ```
+        /// let canShow = session.isApplePayAvailable
+        ///     && !session.getPaymentMethodConfig(.specific("apple_pay")).isEmpty
+        /// ```
         public var isApplePayAvailable: Bool {
-            guard let option = config.paymentOption(for: .applePay),
-                  case let .applePay(applePayConfig) = option.config else {
-                return false
-            }
-            let pkNetworks = applePayConfig.parameters.supportedNetworks
-                .compactMap { PKPaymentNetwork(rawValue: $0) }
-            guard !pkNetworks.isEmpty else { return false }
-            return PKPaymentAuthorizationController.canMakePayments(usingNetworks: pkNetworks)
+            PKPaymentAuthorizationController.canMakePayments()
         }
 
         func isPaymentCodeAvailable(paymentMethodCode: String) -> Bool {

--- a/Payrails/Classes/Public/PayrailsSession.swift
+++ b/Payrails/Classes/Public/PayrailsSession.swift
@@ -498,11 +498,11 @@ extension Payrails.Session {
         return PublicSDKConfig(from: config)
     }
 
-    func deleteInstrument(instrumentId: String) async throws -> DeleteInstrumentResponse {
+    public func deleteInstrument(instrumentId: String) async throws -> DeleteInstrumentResponse {
         return try await payrailsAPI.deleteInstrument(instrumentId: instrumentId)
     }
 
-    func updateInstrument(instrumentId: String, body: UpdateInstrumentBody) async throws -> UpdateInstrumentResponse {
+    public func updateInstrument(instrumentId: String, body: UpdateInstrumentBody) async throws -> UpdateInstrumentResponse {
         return try await payrailsAPI.updateInstrument(instrumentId: instrumentId, body: body)
     }
 

--- a/Payrails/Classes/Public/PayrailsSession.swift
+++ b/Payrails/Classes/Public/PayrailsSession.swift
@@ -41,10 +41,6 @@ public extension Payrails {
             }
         }
 
-        func isPaymentAvailable(type: PaymentType) -> Bool {
-            return config.paymentOption(for: type) != nil
-        }
-
         /// Returns `true` if the device supports Apple Pay at the platform level.
         ///
         /// This is a pure device-capability check (backed by
@@ -61,10 +57,6 @@ public extension Payrails {
         /// ```
         public var isApplePayAvailable: Bool {
             PKPaymentAuthorizationController.canMakePayments()
-        }
-
-        func isPaymentCodeAvailable(paymentMethodCode: String) -> Bool {
-            return config.paymentOption(forPaymentMethodCode: paymentMethodCode) != nil
         }
 
         func storedInstruments(for type: Payrails.PaymentType) -> [StoredInstrument] {

--- a/Payrails/Classes/Public/PayrailsSession.swift
+++ b/Payrails/Classes/Public/PayrailsSession.swift
@@ -41,7 +41,7 @@ public extension Payrails {
             }
         }
 
-        func isPaymentAvailable(type: PaymentType) -> Bool {
+        public func isPaymentAvailable(type: PaymentType) -> Bool {
             return config.paymentOption(for: type) != nil
         }
 
@@ -49,11 +49,11 @@ public extension Payrails {
             return config.paymentOption(for: .applePay) != nil
         }
 
-        func isPaymentCodeAvailable(paymentMethodCode: String) -> Bool {
+        public func isPaymentCodeAvailable(paymentMethodCode: String) -> Bool {
             return config.paymentOption(forPaymentMethodCode: paymentMethodCode) != nil
         }
 
-        func storedInstruments(for type: Payrails.PaymentType) -> [StoredInstrument] {
+        public func storedInstruments(for type: Payrails.PaymentType) -> [StoredInstrument] {
             guard let paymentInstruments = config.paymentOption(for: type, extra: {
                 guard let paymentInstruments = $0.paymentInstruments else { return false }
                 switch paymentInstruments {
@@ -161,7 +161,7 @@ public extension Payrails {
             paymentHandler.makePayment(total: total, currency: config.amount.currency, presenter: presenter)
         }
 
-        func cancelPayment() {
+        public func cancelPayment() {
             isPaymentInProgress = false
             currentTask?.cancel()
             currentTask = nil
@@ -484,7 +484,7 @@ extension Payrails.Session {
     }
 }
 
-extension Payrails.Session {
+public extension Payrails.Session {
     func update(_ options: UpdateOptions) {
         if let amount = options.amount {
             config.amount = Amount(value: amount.value, currency: amount.currency)
@@ -533,7 +533,7 @@ extension Payrails.Session {
 
     /// Read-only access to SDK configuration and session state.
     /// Mirrors the web SDK's `payrails.query(key, params)` API.
-    func query(_ key: PayrailsQueryKey) -> PayrailsQueryResult? {
+    public func query(_ key: PayrailsQueryKey) -> PayrailsQueryResult? {
         switch key {
         case .holderReference:
             guard let value = config?.holderReference else { return nil }

--- a/PayrailsTests/PayrailsTests.swift
+++ b/PayrailsTests/PayrailsTests.swift
@@ -2328,6 +2328,45 @@ final class PayrailsTests: XCTestCase {
         }
     }
 
+    // MARK: - getPaymentMethodConfig(_:) tests
+
+    func testGetPaymentMethodConfigAllReturnsEveryConfiguredMethod() throws {
+        let session = try makeQueryTestSession()
+        let options = session.getPaymentMethodConfig(.all)
+        XCTAssertEqual(options.count, 2)
+        XCTAssertTrue(options.contains { $0.paymentMethodCode == "card" })
+        XCTAssertTrue(options.contains { $0.paymentMethodCode == "payPal" })
+    }
+
+    func testGetPaymentMethodConfigDefaultsToAll() throws {
+        let session = try makeQueryTestSession()
+        let options = session.getPaymentMethodConfig()
+        XCTAssertEqual(options.count, 2)
+    }
+
+    func testGetPaymentMethodConfigRedirectFiltersByFlow() throws {
+        let session = try makeQueryTestSession()
+        let options = session.getPaymentMethodConfig(.redirect)
+        XCTAssertEqual(options.count, 1)
+        XCTAssertEqual(options.first?.paymentMethodCode, "payPal")
+        XCTAssertEqual(options.first?.clientConfig?.flow, "redirect")
+    }
+
+    func testGetPaymentMethodConfigSpecificReturnsSingleMatch() throws {
+        let session = try makeQueryTestSession()
+        let options = session.getPaymentMethodConfig(.specific("card"))
+        XCTAssertEqual(options.count, 1)
+        XCTAssertEqual(options.first?.paymentMethodCode, "card")
+        XCTAssertEqual(options.first?.clientConfig?.displayName, "Credit Card")
+        XCTAssertEqual(options.first?.clientConfig?.flow, "inline")
+    }
+
+    func testGetPaymentMethodConfigSpecificUnknownReturnsEmptyArray() throws {
+        let session = try makeQueryTestSession()
+        let options = session.getPaymentMethodConfig(.specific("klarna"))
+        XCTAssertTrue(options.isEmpty)
+    }
+
     // MARK: - fieldInsets: Style property tests
 
     func testStyleFieldInsetsDefaultsToNil() throws {

--- a/PayrailsTests/PayrailsTests.swift
+++ b/PayrailsTests/PayrailsTests.swift
@@ -1946,30 +1946,6 @@ final class PayrailsTests: XCTestCase {
         XCTAssertEqual(response.data.binLookup?.type, "credit")
     }
 
-    func testInstrumentAPIResponseSaveCase() {
-        let json = """
-        {
-            "id": "instr-api-1",
-            "createdAt": "2025-01-01T00:00:00Z",
-            "holderId": "holder-api-1",
-            "paymentMethod": "card",
-            "status": "enabled",
-            "data": {}
-        }
-        """
-        let jsonData = Data(json.utf8)
-
-        let saveResponse = try! JSONDecoder().decode(SaveInstrumentResponse.self, from: jsonData)
-        let apiResponse = InstrumentAPIResponse.save(saveResponse)
-
-        switch apiResponse {
-        case .save(let response):
-            XCTAssertEqual(response.id, "instr-api-1")
-        default:
-            XCTFail("Expected .save case")
-        }
-    }
-
     func testUpdateInstrumentBodyEncoding() throws {
         let body = UpdateInstrumentBody(
             status: "enabled",

--- a/README.md
+++ b/README.md
@@ -306,10 +306,9 @@ setDefaultButton.isEnabled = !selectedCard.isDefault
 To mark an instrument as default:
 
 ```swift
-let result = try await Payrails.api(
-    "updateInstrument",
-    instrumentId,
-    UpdateInstrumentBody(default: true)
+let response = try await session.updateInstrument(
+    instrumentId: instrumentId,
+    body: UpdateInstrumentBody(default: true)
 )
 ```
 
@@ -368,15 +367,17 @@ func onStoredInstrumentChanged(_ button: Payrails.CardPaymentButton, instrument:
 
 ### Managing stored instruments
 
-Use `Payrails.api` to delete or update a stored instrument:
+Call the typed methods on your `Payrails.Session` to delete or update a stored instrument:
 
 ```swift
 // Delete
-let result = try await Payrails.api("deleteInstrument", instrumentId)
+let response = try await session.deleteInstrument(instrumentId: instrumentId)
 
 // Update (set as default)
-let body = UpdateInstrumentBody(default: true)
-let result = try await Payrails.api("updateInstrument", instrumentId, body)
+let response = try await session.updateInstrument(
+    instrumentId: instrumentId,
+    body: UpdateInstrumentBody(default: true)
+)
 ```
 
 ## Payment Amount Update

--- a/README.md
+++ b/README.md
@@ -400,6 +400,15 @@ let result = Payrails.query(.holderReference)
 
 Returns `nil` if the SDK has not been initialized or the requested value is not present.
 
+### `query(_:)` vs Session methods — when to use which
+
+| Use | For | Examples |
+|---|---|---|
+| **`query(_:)`** | Stateless reads of session metadata | `.holderReference`, `.amount`, `.executionId`, `.binLookup`, `.paymentMethodConfig(...)`, `.paymentMethodInstruments(...)` |
+| **Session methods** | Actions / mutations, device-capability checks, typed reads | `session.executePayment(...)`, `session.deleteInstrument(...)`, `session.updateInstrument(...)`, `session.update(...)`, `session.isApplePayAvailable`, `session.getPaymentMethodConfig(...)` |
+
+Rule of thumb: **`query(_:)` reads data. Session methods do things, check the device, or return typed values where an enum would add friction.**
+
 ### Available query keys
 
 | Key | Return case | Description |

--- a/docs/card-payment-flow-documentation.md
+++ b/docs/card-payment-flow-documentation.md
@@ -131,8 +131,8 @@ func executePayment(
     presenter: PaymentPresenter?
 ) async -> OnPayResult
 
-func isPaymentAvailable(type: PaymentType) -> Bool
-func storedInstruments(for type: PaymentType) -> [StoredInstrument]
+func getPaymentMethodConfig(_ filter: PaymentMethodFilter = .all) -> [PayrailsPaymentOption]
+func query(_ key: PayrailsQueryKey) -> PayrailsQueryResult?
 ```
 
 **Key Properties**:

--- a/docs/internal/merchant-usage-guide.md
+++ b/docs/internal/merchant-usage-guide.md
@@ -255,7 +255,7 @@ extension CheckoutViewController: PayrailsStoredInstrumentsDelegate {
                            didRequestDeleteInstrument instrument: StoredInstrument) {
         // Show confirmation alert, then:
         Task {
-            let response = try await Payrails.api("deleteInstrument", instrument.id)
+            let response = try await session.deleteInstrument(instrumentId: instrument.id)
             // Refresh the instruments view
             view.refreshInstruments()
         }
@@ -265,7 +265,7 @@ extension CheckoutViewController: PayrailsStoredInstrumentsDelegate {
                            didRequestUpdateInstrument instrument: StoredInstrument) {
         let body = UpdateInstrumentBody(/* isDefault: true */)
         Task {
-            let response = try await Payrails.api("updateInstrument", instrument.id, body)
+            let response = try await session.updateInstrument(instrumentId: instrument.id, body: body)
         }
     }
 }

--- a/docs/internal/public-api-audit.md
+++ b/docs/internal/public-api-audit.md
@@ -20,8 +20,9 @@ Living document tracking every public symbol in the SDK. Update this whenever a 
 | `Payrails.update(_:)` | PUBLIC | Runtime session state mutation (amount only) |
 | `Payrails.getStoredInstruments()` | PUBLIC | Convenience accessor; returns all card + PayPal |
 | `Payrails.getStoredInstruments(for:)` | PUBLIC | Type-filtered accessor |
-| `Payrails.api(_:_:_:)` | PUBLIC | String-based operation dispatch (`"deleteInstrument"`, `"updateInstrument"`). Matches Android SDK pattern. |
 | `Payrails.log(_:separator:terminator:file:function:line:)` | DISCUSS | Currently public — merchants could call this, but it's mainly internal. Consider making internal. |
+
+> **Removed in 1.28.0:** `Payrails.api(_:_:_:)` has been removed. Use typed session methods (`session.deleteInstrument(instrumentId:)` and `session.updateInstrument(instrumentId:body:)`) instead.
 
 ---
 
@@ -287,7 +288,7 @@ Living document tracking every public symbol in the SDK. Update this whenever a 
 ## Open issues
 
 1. **`CardFormStyle` vs `CardFormStylesConfig`** — two overlapping style APIs. `CardFormStylesConfig` is the current standard. `CardFormStyle` is legacy. A deprecation path is needed.
-2. **`Payrails.api(_:_:_:)` string dispatch** — error-prone. Replace with typed methods `Payrails.deleteInstrument(_:)` and `Payrails.updateInstrument(_:body:)`.
+2. **`Payrails.api(_:_:_:)` string dispatch** — removed in 1.28.0 in favour of the typed `session.deleteInstrument(instrumentId:)` and `session.updateInstrument(instrumentId:body:)` methods.
 3. **`CardPaymenButtonTranslations` typo** — "Paymen" should be "Payment". Fix requires a breaking rename. Schedule for next major version.
 4. **Vault types in public namespace** — `Client`, `Container`, `TextField`, etc. are Skyflow internals that accidentally surfaced as public. Audit and make internal.
 5. **`PaymentPresenter.encryptedCardData`** — this property is an implementation detail of the 3DS flow. Review whether it needs to remain public.

--- a/docs/internal/public-api-audit.md
+++ b/docs/internal/public-api-audit.md
@@ -35,11 +35,11 @@ Living document tracking every public symbol in the SDK. Update this whenever a 
 | `Payrails.Session.isApplePayAvailable` | PUBLIC | Used to conditionally show Apple Pay button; combines config + device capability check |
 | `Payrails.Session.isPaymentAvailable(type:)` | INTERNAL | Redundant with `query(.paymentMethodConfig)`; kept internal |
 | `Payrails.Session.isPaymentCodeAvailable(paymentMethodCode:)` | INTERNAL | Redundant with `query(.paymentMethodConfig(.specific(code)))`; kept internal (matches Android SDK) |
-| `Payrails.Session.storedInstruments(for:)` | PUBLIC | Prefer `Payrails.getStoredInstruments(for:)` |
+| `Payrails.Session.storedInstruments(for:)` | INTERNAL | Redundant with `session.query(.paymentMethodInstruments(type:))`; kept internal (matches Android SDK convention) |
 | `Payrails.Session.executePayment(with:...:onResult:)` | PUBLIC | Direct session payment execution |
 | `Payrails.Session.executePayment(withStoredInstrument:...:onResult:)` | PUBLIC | Stored instrument payment |
 | `Payrails.Session.executePayment(with:...) async` | PUBLIC | Async variant |
-| `Payrails.Session.cancelPayment()` | PUBLIC | Cancel in-flight payment |
+| `Payrails.Session.cancelPayment()` | INTERNAL | Only called by SDK UI components on dispose; merchants using async `executePayment(...)` cancel their own `Task`. Matches Android SDK. |
 | `Payrails.Session.tokenize(encryptedData:options:)` | PUBLIC | Card vaulting without payment |
 | `Payrails.Session.deleteInstrument(instrumentId:)` | PUBLIC | Direct instrument deletion |
 | `Payrails.Session.updateInstrument(instrumentId:body:)` | PUBLIC | Direct instrument update |

--- a/docs/internal/public-api-audit.md
+++ b/docs/internal/public-api-audit.md
@@ -32,9 +32,8 @@ Living document tracking every public symbol in the SDK. Update this whenever a 
 |---|---|---|
 | `Payrails.Session` (class) | PUBLIC | Returned from `createSession`; merchants rarely call methods directly |
 | `Payrails.Session.isPaymentInProgress` | PUBLIC | Useful for disabling UI during payment |
-| `Payrails.Session.isApplePayAvailable` | PUBLIC | Used to conditionally show Apple Pay button; combines config + device capability check |
-| `Payrails.Session.isPaymentAvailable(type:)` | INTERNAL | Redundant with `query(.paymentMethodConfig)`; kept internal |
-| `Payrails.Session.isPaymentCodeAvailable(paymentMethodCode:)` | INTERNAL | Redundant with `query(.paymentMethodConfig(.specific(code)))`; kept internal (matches Android SDK) |
+| `Payrails.Session.isApplePayAvailable` | PUBLIC | Pure device-capability check (`PKPaymentAuthorizationController.canMakePayments()`). Config check is separate — use `getPaymentMethodConfig(.specific("apple_pay"))`. Matches web SDK. |
+| `Payrails.Session.getPaymentMethodConfig(_:)` | PUBLIC | Typed getter returning `[PayrailsPaymentOption]`. Mirrors web SDK's `getPaymentMethodConfig(paymentMethod)`. Accepts `.all`, `.redirect`, `.specific(code)`. |
 | `Payrails.Session.storedInstruments(for:)` | INTERNAL | Redundant with `session.query(.paymentMethodInstruments(type:))`; kept internal (matches Android SDK convention) |
 | `Payrails.Session.executePayment(with:...:onResult:)` | PUBLIC | Direct session payment execution |
 | `Payrails.Session.executePayment(withStoredInstrument:...:onResult:)` | PUBLIC | Stored instrument payment |

--- a/docs/internal/public-api-audit.md
+++ b/docs/internal/public-api-audit.md
@@ -32,9 +32,9 @@ Living document tracking every public symbol in the SDK. Update this whenever a 
 |---|---|---|
 | `Payrails.Session` (class) | PUBLIC | Returned from `createSession`; merchants rarely call methods directly |
 | `Payrails.Session.isPaymentInProgress` | PUBLIC | Useful for disabling UI during payment |
-| `Payrails.Session.isApplePayAvailable` | PUBLIC | Used to conditionally show Apple Pay button |
-| `Payrails.Session.isPaymentAvailable(type:)` | PUBLIC | Conditional payment method display |
-| `Payrails.Session.isPaymentCodeAvailable(paymentMethodCode:)` | PUBLIC | Generic redirect availability check |
+| `Payrails.Session.isApplePayAvailable` | PUBLIC | Used to conditionally show Apple Pay button; combines config + device capability check |
+| `Payrails.Session.isPaymentAvailable(type:)` | INTERNAL | Redundant with `query(.paymentMethodConfig)`; kept internal |
+| `Payrails.Session.isPaymentCodeAvailable(paymentMethodCode:)` | INTERNAL | Redundant with `query(.paymentMethodConfig(.specific(code)))`; kept internal (matches Android SDK) |
 | `Payrails.Session.storedInstruments(for:)` | PUBLIC | Prefer `Payrails.getStoredInstruments(for:)` |
 | `Payrails.Session.executePayment(with:...:onResult:)` | PUBLIC | Direct session payment execution |
 | `Payrails.Session.executePayment(withStoredInstrument:...:onResult:)` | PUBLIC | Stored instrument payment |

--- a/docs/public/how-to-query-session-data.md
+++ b/docs/public/how-to-query-session-data.md
@@ -7,6 +7,13 @@ title: How to Query Session Data
 
 `Payrails.query(_:)` provides read-only access to the current session's configuration and state. Use it to retrieve the execution ID, payment amount, stored instruments, API links, and more — without reaching into internal session state.
 
+## When to use `query(_:)` vs Session methods
+
+- **Use `query(_:)`** for stateless reads of session metadata: `.holderReference`, `.amount`, `.executionId`, `.binLookup`, `.paymentMethodConfig(...)`, `.paymentMethodInstruments(...)`.
+- **Use Session methods directly** for actions (`executePayment`, `deleteInstrument`, `updateInstrument`, `update`), device-capability checks (`isApplePayAvailable`), or typed reads where merchants prefer concrete return types over an enum (`getPaymentMethodConfig(_:)`).
+
+Rule of thumb: **`query(_:)` reads data. Session methods do things, check the device, or return typed values where an enum would add friction.**
+
 ## Prerequisites
 
 An active session must exist (created via `Payrails.createSession(with:)`). All queries return `nil` when no session is active.

--- a/docs/public/sdk-api-reference.md
+++ b/docs/public/sdk-api-reference.md
@@ -88,12 +88,17 @@ public typealias OnInitCallback = (Result<Payrails.Session, PayrailsError>) -> V
 
 ## Session
 
-`Payrails.Session` is returned from `createSession` and is the single typed API surface for headless integrations. All session data reads go through `query(_:)` — there are no dedicated getters.
+`Payrails.Session` is returned from `createSession` and is the single typed API surface for headless integrations. Session data reads go through the unified `query(_:)` accessor. A typed `getPaymentMethodConfig(_:)` mirrors the web SDK pattern for merchants who prefer direct getters over the query enum.
 
 ```swift
 public class Payrails.Session {
-    // Availability
+    // Availability — device capability only
+    // Compose with getPaymentMethodConfig(.specific("apple_pay")) for
+    // the combined "configured and device capable" signal.
     public var isApplePayAvailable: Bool { get }
+
+    // Payment method configuration
+    public func getPaymentMethodConfig(_ filter: PaymentMethodFilter = .all) -> [PayrailsPaymentOption]
 
     // Payment execution — callback variants
     public func executePayment(

--- a/docs/public/sdk-api-reference.md
+++ b/docs/public/sdk-api-reference.md
@@ -88,19 +88,15 @@ public typealias OnInitCallback = (Result<Payrails.Session, PayrailsError>) -> V
 
 ## Session
 
-`Payrails.Session` is returned from `createSession`. You rarely need to call methods on it directly; prefer the static factory methods on `Payrails` instead.
+`Payrails.Session` is returned from `createSession` and is the single typed API surface for headless integrations. All session data reads go through `query(_:)` — there are no dedicated getters.
 
 ```swift
 public class Payrails.Session {
-    var isPaymentInProgress: Bool { get }
+    // Availability
+    public var isApplePayAvailable: Bool { get }
 
-    func isPaymentAvailable(type: PaymentType) -> Bool
-    func isPaymentCodeAvailable(paymentMethodCode: String) -> Bool
-    var isApplePayAvailable: Bool { get }
-
-    func storedInstruments(for type: Payrails.PaymentType) -> [StoredInstrument]
-
-    func executePayment(
+    // Payment execution — callback variants
+    public func executePayment(
         with type: PaymentType,
         paymentMethodCode: String?,
         saveInstrument: Bool,
@@ -108,32 +104,32 @@ public class Payrails.Session {
         onResult: @escaping OnPayCallback
     )
 
-    func executePayment(
+    public func executePayment(
         withStoredInstrument instrument: StoredInstrument,
         presenter: PaymentPresenter?,
         onResult: @escaping OnPayCallback
     )
 
-    func cancelPayment()
-
-    // Async variants
-    @MainActor func executePayment(
+    // Payment execution — async variants
+    @MainActor public func executePayment(
         with type: Payrails.PaymentType,
         paymentMethodCode: String?,
         saveInstrument: Bool,
         presenter: PaymentPresenter?
     ) async -> OnPayResult
 
-    @MainActor func executePayment(
+    @MainActor public func executePayment(
         withStoredInstrument instrument: StoredInstrument,
         presenter: PaymentPresenter?
     ) async -> OnPayResult
 
-    func update(_ options: UpdateOptions)
-    func query(_ key: PayrailsQueryKey) -> PayrailsQueryResult?
-    func tokenize(encryptedData: String, options: TokenizeOptions) async throws -> SaveInstrumentResponse
-    func deleteInstrument(instrumentId: String) async throws -> DeleteInstrumentResponse
-    func updateInstrument(instrumentId: String, body: UpdateInstrumentBody) async throws -> UpdateInstrumentResponse
+    // Instrument management
+    public func deleteInstrument(instrumentId: String) async throws -> DeleteInstrumentResponse
+    public func updateInstrument(instrumentId: String, body: UpdateInstrumentBody) async throws -> UpdateInstrumentResponse
+
+    // Session state
+    public func query(_ key: PayrailsQueryKey) -> PayrailsQueryResult?
+    public func update(_ options: UpdateOptions)
 }
 ```
 

--- a/docs/public/sdk-api-reference.md
+++ b/docs/public/sdk-api-reference.md
@@ -88,7 +88,14 @@ public typealias OnInitCallback = (Result<Payrails.Session, PayrailsError>) -> V
 
 ## Session
 
-`Payrails.Session` is returned from `createSession` and is the single typed API surface for headless integrations. Session data reads go through the unified `query(_:)` accessor. A typed `getPaymentMethodConfig(_:)` mirrors the web SDK pattern for merchants who prefer direct getters over the query enum.
+`Payrails.Session` is returned from `createSession` and is the single typed API surface for headless integrations.
+
+**When to use `query(_:)` vs session methods directly:**
+
+- **`query(_:)`** — stateless reads of session metadata (holder reference, amount, execution ID, API links, payment method config, stored instruments). Single unified accessor returning a `PayrailsQueryResult` enum.
+- **Session methods** — actions and mutations (`executePayment`, `deleteInstrument`, `updateInstrument`, `update`), device-capability checks (`isApplePayAvailable`), or typed reads where merchants prefer concrete return types over an enum (`getPaymentMethodConfig(_:)`).
+
+Rule of thumb: **`query(_:)` reads data; session methods do things, check the device, or return typed values.**
 
 ```swift
 public class Payrails.Session {


### PR DESCRIPTION
## Description
## Summary

Unblocks Blacklane's headless iOS SDK integration by making `Payrails.Session` the single typed public API surface. Removes the `Payrails.api(...)` string-dispatch workaround and restores public access to payment execution, instrument management, and query methods that regressed to `internal` in 1.26.1.

**Ticket:** [ONB-521](https://linear.app/payrails/issue/ONB-521/make-stored-instrument-payment-api-public-again)

---

## Issues Addressed

Tracking the merchant feedback items that landed in this PR:

| # | Issue | Fix |
|---|---|---|
| 5 | `Session.executePayment(withStoredInstrument:)` was `internal` | Made `public` — 2 callback + 2 async variants |
| 6 | `Session.executePayment(with: .applePay, ...)` was `internal` | Made `public` alongside item 5 |
| 7 | `deleteInstrument`/`updateInstrument` only reachable via string dispatch | Exposed typed session methods; removed `Payrails.api(...)` |
| 10 | `isApplePayAvailable` did not account for device capability | Added `PKPaymentAuthorizationController.canMakePayments(usingNetworks:)` check |
| — | Query / state methods (`query`, `storedInstruments(for:)`, `cancelPayment`, `update`, `isPaymentAvailable`, `isPaymentCodeAvailable`) were `internal` | Made `public` to complete the surface |
---

## Breaking Change

`Payrails.api(_:_:_:)` and `InstrumentAPIResponse` are **removed**. Callers must migrate to the typed session methods:

```swift
// Before (removed)
let result = try await Payrails.api("deleteInstrument", id)
switch result {
case .delete(let r) where r.success: ...
default: ...
}

// After
let response = try await session.deleteInstrument(instrumentId: id)
if response.success { ... }
```
## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [x] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Release
- [ ] ⏩ Revert

## Screenshots/Recordings

<!-- Visual changes require screenshots -->

## Added tests?

- [x] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?

- [x] 📜 README.md
- [x] 🗂️ Internal documentation
- [x] 📓 Public Documentation (docs.payrails.com)
- [ ] 🙅 no documentation needed

## [optional] Are there any post-release tasks we need to perform?
