### PR TITLE
ONB-739: Fix 3Ds hanging flows and dismissible popups 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `AuthorizationFailure` struct — payload passed to `onAuthorizeFailed(_:failure:)` on every delegate protocol. Carries `code: AuthorizationFailureReason` (discriminator), `message: String` (backend detail or generic fallback — never nil), and `rawError: Error?` (the underlying error when one exists). Flat `{ code, message, rawError }` shape, matching the Web SDK's `onFailed` payload. (ONB-739)
+- `AuthorizationFailureReason` enum — string-raw-valued discriminator on `AuthorizationFailure.code`. Four cases mirror the Web SDK 1:1: `.authorizationError` ("AUTHORIZATION_ERROR"), `.authenticationError` ("AUTHENTICATION_ERROR"), `.userCancelled` ("USER_CANCELLED"), `.unknownError` ("UNKNOWN_ERROR"). Web's `VALIDATION_FAILED` is intentionally absent — input validation runs client-side before submission. (ONB-739)
+- `SessionExpiredHandler` closure type and a new `onSessionExpired:` parameter on `Payrails.createSession(...)` (both callback and `async` overloads). The merchant supplies a closure that fetches a fresh `InitData` from their backend; the SDK invokes it when it detects the current Payrails execution is no longer reusable and swaps its internal config in place — the merchant's cached `Session` reference and any buttons / forms keep working unchanged. (ONB-739, see ADR-001)
+- `OnPayResult.pending` case for the backend-pending-execution path. Surfaced when the backend returns `pending` with `actionRequired: nil` (no 3DS, no redirect — execution still live and may settle later). Routed to merchants via `onAuthorizePending(_:)`. (ONB-739)
+- Concurrent backend polling during 3DS — a background poll task now runs alongside the WebView so the SDK can resolve payments even when the WebView's redirect chain stalls. A single-shot `claimTerminal()` NSLock arbitrates between WebView URL signals and polling signals so exactly one path reports the outcome. (ONB-739)
+- User-dismiss detection on the 3DS WebView via `UIAdaptivePresentationControllerDelegate.presentationControllerDidDismiss(_:)`. After a 3-attempt × 1s confirmation poll for a real backend terminal, an unresolved dismiss surfaces as `OnPayResult.authorizationFailed(.userCancelled)` and triggers the `onSessionExpired` refresh. (ONB-739)
+
+### Changed
+- **Breaking:** `onAuthorizeFailed(_:)` is now `onAuthorizeFailed(_:failure:)` on every delegate protocol (`PayrailsCardPaymentButtonDelegate`, `PayrailsCardPaymentFormDelegate`, `PayrailsStoredInstrumentPaymentButtonDelegate`, `GenericRedirectPaymentButtonDelegate`). The new `failure: AuthorizationFailure` parameter carries the discriminating code, the backend message, and the raw error. Merchants switch on `failure.code` and read `failure.message` / `failure.rawError`. (ONB-739)
+- **Breaking:** `OnPayResult` collapsed to three cases: `.success`, `.authorizationFailed(AuthorizationFailure)`, `.pending`. The previous `.authorizationFailed`, `.failure`, `.error(_:)`, and `.cancelledByUser` cases are merged into `.authorizationFailed(_)` — the carried `AuthorizationFailure` discriminates via `.code`. User-cancel surfaces as `.authorizationFailed(.userCancelled)` (not a top-level case). Callers of `session.executePayment(..., onResult:)` must update their switch statements. (ONB-739)
+- When the backend returns `pending(executionResult)`, the SDK now branches on `executionResult.actionRequired`: if nil, surface `OnPayResult.pending` to the caller immediately (no 3DS challenge presented); if present, perform the action and start the background poll as before. (ONB-739)
+- Sessions left in `authorizePending` after the user abandons a 3DS challenge are now refreshed automatically by the SDK via the merchant's `onSessionExpired` closure. The merchant's `Session` reference and cached buttons / forms keep working — only the underlying execution changes. If no closure was supplied at `createSession`, the SDK logs a warning at init and the next payment attempt fails naturally against the dead execution. (ONB-739)
+
+### Removed
+- **Breaking:** `onSessionExpired(_:)` delegate method on `PayrailsCardPaymentButtonDelegate`, `PayrailsCardPaymentFormDelegate`, `PayrailsStoredInstrumentPaymentButtonDelegate`, and `GenericRedirectPaymentButtonDelegate` is gone. Session refresh moved from a per-button delegate callback to a Session-init closure (see Added). Merchants who implemented the delegate method should remove it and supply the closure to `createSession` instead. (ONB-739, see ADR-001 — driven by review feedback from @kumaraksi on PR #78)
+
+> ⚠️ **Breaking change:** Existing merchants who conform to any of the four card/redirect delegate protocols must update their `onAuthorizeFailed` signature to take `failure: AuthorizationFailure` instead of no payload. See `docs/public/quick-start.md` for the new switch pattern.
+
+### Fixed
+- 3DS WebView no longer hangs indefinitely when the backend redirect chain stalls on `/redirect/wait/workflow/…` or lands on an unrecognized URL — the concurrent backend poll surfaces the real terminal status. (ONB-739)
+- User dismissing the 3DS sheet (swipe-down) now fires `onAuthorizeFailed(_:failure:)` with `failure.code == .userCancelled` instead of leaving the merchant app in "Processing payment…" indefinitely. (ONB-739)
+- Backend's `errors[0].reason.result` is now threaded through to `AuthorizationFailure.message` instead of being dropped. Merchants get actionable backend copy ("ParamsError", "Insufficient funds", etc.) on the failure callback. (ONB-739)
+- Sessions left in `authorizePending` after a 3DS dismissal are now refreshed automatically by the SDK (via the `onSessionExpired` closure supplied at `createSession`). Previously, merchants had to detect this externally and rebuild the `Session` themselves, which was error-prone across cached button / form references. (ONB-739)
+- The 3-second fixed `Task.sleep` previously used as the user-dismiss grace window has been replaced with a 3-attempt × 1s confirmation-poll loop, eliminating false user-cancel reports when the backend reaches a real terminal within the window. (ONB-739)
+
+### Documentation
+- `docs/public/sdk-api-reference.md` no longer publicly documents `OnPayResult`; the public surface is the `createSession(with:onSessionExpired:)` constructor plus the delegate API (`onAuthorizeSuccess`, `onAuthorizeFailed(_:failure:)`, `onAuthorizePending`). `AuthorizationFailure` and `AuthorizationFailureReason` are documented as the failure payload and discriminator. (ONB-739)
+- ADR-001 captures the design rationale for moving from a per-button `onSessionExpired` delegate to the refresh-closure pattern. (ONB-739)
+
 ## [1.28.0] - 2026-04-22
 
 ### Added

--- a/Payrails/Classes/Public/Domains/Callbacks.swift
+++ b/Payrails/Classes/Public/Domains/Callbacks.swift
@@ -3,6 +3,140 @@ import Foundation
 public typealias OnInitCallback = ((Result<Payrails.Session, PayrailsError>) -> Void)
 public typealias OnPayCallback = ((OnPayResult) -> Void)
 
+/// Closure the merchant provides at `Payrails.createSession` time. The SDK invokes it
+/// when it detects the current Payrails execution is no longer reusable — most commonly
+/// when the user abandoned 3DS and the execution is stuck in `authorizePending`.
+///
+/// The merchant fetches a fresh init payload from their backend and calls `completion`
+/// with the new `InitData`. The SDK then swaps its internal config in place so the next
+/// payment attempt works against the fresh execution — the merchant's existing
+/// `Session` reference and any cached buttons / forms keep working unchanged.
+///
+///     let session = try await Payrails.createSession(
+///         with: configuration,
+///         onSessionExpired: { completion in
+///             myBackend.fetchPayrailsInit { result in
+///                 switch result {
+///                 case let .success(initData):
+///                     completion(.success(initData))
+///                 case let .failure(error):
+///                     completion(.failure(error))
+///                 }
+///             }
+///         }
+///     )
+///
+/// If the closure is omitted, the SDK has no way to refresh itself. The next payment
+/// attempt against the poisoned Session will fail with whatever the dead execution
+/// emits (typically `.authorizationError(message: "Authorization failed")`). The SDK
+/// logs a warning in this case.
+public typealias SessionExpiredHandler = (
+    @escaping (Result<Payrails.InitData, Error>) -> Void
+) -> Void
+
+/// The result type emitted by the low-level `OnPayCallback` API.
+///
+/// **Audience.** Most merchants integrate via the higher-level **delegate-driven button
+/// API** (`Payrails.CardPaymentButton`, `Payrails.CardPaymentForm`, etc.) and never
+/// observe `OnPayResult` directly. The buttons translate each case into the appropriate
+/// delegate method. `OnPayResult` is the lower layer used by callers of
+/// `session.executePayment(..., onResult:)` and as the internal vocabulary between
+/// `Session` and the buttons.
+///
+/// **Mapping to delegate calls** (performed by each button's `handlePaymentResult`):
+///
+///     OnPayResult                            delegate call(s)
+///     ────────────────────────────────────── ───────────────────────────────────────────────
+///     .success                               onAuthorizeSuccess(self)
+///     .authorizationFailed(failure)          onAuthorizeFailed(self, failure: failure)
+///     .pending                               onAuthorizePending(self)
 public enum OnPayResult {
-    case success, authorizationFailed, failure, error(PayrailsError), cancelledByUser
+    case success
+    /// The payment did not authorize. The associated `AuthorizationFailure` carries the
+    /// discriminating `code` (issuer/3DS decline, auth/token error, user cancel, or
+    /// unexpected error), a human-readable `message`, and the underlying `rawError` when one
+    /// exists. Mirrors the Web SDK's `onFailed(action, { code, message, rawError })`.
+    case authorizationFailed(AuthorizationFailure)
+    /// The Payrails execution is in pending state on the backend with no action for the SDK
+    /// to perform — the backend returned `authorizePending` and `actionRequired` was nil.
+    /// Surfaced to the merchant via `onAuthorizePending`. No session refresh is triggered:
+    /// the execution is still live and may settle later.
+    case pending
+}
+
+/// Discriminating code for an authorization failure. Raw values match the Web SDK's
+/// `AuthorizationFailureReasons` string constants so both SDKs report identical codes.
+///
+/// Web's `VALIDATION_FAILED` is intentionally absent: input validation happens client-side
+/// before submission and never reaches this path (the button early-returns on an invalid
+/// form instead of emitting a failure).
+public enum AuthorizationFailureReason: String {
+    /// The authorization was rejected by the backend — issuer declined, 3DS rejected, fraud
+    /// blocked, etc. The accompanying `message` carries the backend detail
+    /// (`errors[0].reason.result`).
+    case authorizationError = "AUTHORIZATION_ERROR"
+
+    /// The session token was rejected (HTTP 401 / 403). The merchant must re-initialise the
+    /// session; the SDK also fires its `onSessionExpired` refresh in the background.
+    case authenticationError = "AUTHENTICATION_ERROR"
+
+    /// The user intentionally abandoned the flow — e.g. swiped the 3DS challenge sheet away,
+    /// or the issuer redirected to the cancel URL.
+    case userCancelled = "USER_CANCELLED"
+
+    /// Network failure, decode error, encryption failure, polling timeout, or any other
+    /// unexpected error. The SDK never invents an `authorizationError`; anything it cannot
+    /// attribute to a backend authorization decision lands here, with `rawError` attached.
+    case unknownError = "UNKNOWN_ERROR"
+}
+
+/// The payload passed to `onAuthorizeFailed(_:failure:)` on every card-family delegate and
+/// carried inside `OnPayResult.authorizationFailed(_:)`.
+///
+/// Flat `{ code, message, rawError }` shape, matching the Web SDK's `onFailed` payload.
+/// Construct via the static helpers (`.authorizationError(message:)`, `.userCancelled`,
+/// `.authenticationError`, `.unknownError(_:)`) so call sites stay terse, or via the
+/// memberwise initializer when a custom message is needed.
+public struct AuthorizationFailure {
+    public let code: AuthorizationFailureReason
+    public let message: String
+    public let rawError: Error?
+
+    public init(code: AuthorizationFailureReason, message: String, rawError: Error? = nil) {
+        self.code = code
+        self.message = message
+        self.rawError = rawError
+    }
+}
+
+public extension AuthorizationFailure {
+    /// Backend-rejected authorization. `message` is the backend detail
+    /// (`errors[0].reason.result`), with a generic fallback supplied by the caller.
+    static func authorizationError(message: String) -> AuthorizationFailure {
+        AuthorizationFailure(code: .authorizationError, message: message, rawError: nil)
+    }
+
+    /// Session token expired / rejected (HTTP 401 / 403).
+    static var authenticationError: AuthorizationFailure {
+        AuthorizationFailure(
+            code: .authenticationError,
+            message: "Authentication failed: the session token has expired or is invalid.",
+            rawError: nil
+        )
+    }
+
+    /// User abandoned the flow (swiped the 3DS sheet away, or issuer hit the cancel URL).
+    static var userCancelled: AuthorizationFailure {
+        AuthorizationFailure(code: .userCancelled, message: "User abandoned the flow.", rawError: nil)
+    }
+
+    /// Unexpected error. `message` is derived from the supplied error when available; the
+    /// error itself is preserved on `rawError`.
+    static func unknownError(_ error: PayrailsError?) -> AuthorizationFailure {
+        AuthorizationFailure(
+            code: .unknownError,
+            message: error?.errorDescription ?? "An unexpected error occurred.",
+            rawError: error
+        )
+    }
 }

--- a/Payrails/Classes/Public/Domains/SDKConfig.swift
+++ b/Payrails/Classes/Public/Domains/SDKConfig.swift
@@ -62,6 +62,21 @@ struct Execution: Decodable {
 struct Status: Decodable {
     let code: String
     let time: Date
+    let errors: [StatusError]?
+}
+
+struct StatusError: Decodable {
+    let id: String?
+    let code: String?
+    let detail: String?
+    let docUrl: String?
+    let reason: StatusErrorReason?
+}
+
+struct StatusErrorReason: Decodable {
+    let category: String?
+    let result: String?
+    let source: String?
 }
 
 struct ExecutionLinks: Decodable {

--- a/Payrails/Classes/Public/PaymentHelpers/CardPaymentHandler.swift
+++ b/Payrails/Classes/Public/PaymentHelpers/CardPaymentHandler.swift
@@ -11,6 +11,14 @@ class CardPaymentHandler: NSObject {
     private var selfLink: String
     private var confirmLink: Link?
 
+    /// Set when the user interactively dismissed the 3DS sheet (swipe-down). Used by
+    /// the WebView navigation delegate to suppress in-flight terminal-URL matches
+    /// (e.g. an issuer redirect to `payrails-error.html` happening concurrently with
+    /// the dismiss). Without this guard, the navigation path can claim the terminal
+    /// first and surface `.error(nil)` → `.unknownError` instead of the swipe's
+    /// intended `.userCancelled` outcome.
+    private var userDidDismissChallenge = false
+
     init(
         delegate: PaymentHandlerDelegate?,
         saveInstrument: Bool,
@@ -95,8 +103,26 @@ extension CardPaymentHandler: PaymentHandler {
                 url: url,
                 delegate: self
             )
+            webViewController.onUserDismiss = { [weak self] in
+                guard let self = self else { return }
+                // Mark BEFORE delegating so any concurrent WebView navigation that
+                // hasn't yet hit `decidePolicyFor` will see the flag and skip its
+                // URL-match terminal action.
+                self.userDidDismissChallenge = true
+                self.delegate?.paymentHandlerUserDidDismissChallenge(handler: self)
+            }
             self.presenter?.presentPayment(webViewController)
             self.webViewController = webViewController
+        }
+    }
+
+    func dismissPresentedView() {
+        // Strong-capture self: when called as part of session teardown, the Session may
+        // release its reference to this handler before the main-queue block runs. The
+        // closure is short-lived so keeping a strong ref for its duration is safe.
+        DispatchQueue.main.async {
+            self.webViewController?.dismiss(animated: true)
+            self.webViewController = nil
         }
     }
 
@@ -151,6 +177,16 @@ extension CardPaymentHandler: PaymentHandler {
 extension CardPaymentHandler: WKNavigationDelegate {
 
     func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction, decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
+
+        // If the user already dismissed the sheet (swipe-down), the swipe-dismiss
+        // handler owns the outcome. Suppress any in-flight terminal-URL matches —
+        // they would otherwise race ahead and claim the terminal first, surfacing
+        // `.unknownError` / `.userCancelled` from the URL match instead of the
+        // intended `.pending` (→ `.userCancelled` + `onSessionExpired`) flow.
+        if userDidDismissChallenge {
+            decisionHandler(.cancel)
+            return
+        }
 
         guard let urlString = navigationAction.request.mainDocumentURL?.absoluteString else {            decisionHandler(.allow)
             return

--- a/Payrails/Classes/Public/PaymentHelpers/PayrailsAPI.swift
+++ b/Payrails/Classes/Public/PaymentHelpers/PayrailsAPI.swift
@@ -8,8 +8,17 @@ class PayrailsAPI {
     var authorizeRequestDate  = Date()
 
     enum PaymentStatus {
-        case success, failed, pending(GetExecutionResult)
+        case success
+        /// Carries the backend's failure message, extracted from the matched
+        /// `authorizeFailed` status entry's `errors[0].reason.result`. Falls back to
+        /// "Authorization failed" when the backend provides no detail, so callers
+        /// never see nil. Mirrors web-sdk's `confirmResult.finalState?.errors?.[0]?.reason?.result || 'Authorization Failed'`.
+        case failed(message: String)
+        case pending(GetExecutionResult)
     }
+
+    /// Fallback message used when the backend payload provides no `errors[0].reason.result`.
+    static let genericAuthorizationFailedMessage = "Authorization failed"
 
     enum PaymentAuthorizeStatus: String {
         case authorizePending, authorizeSuccessful, authorizeFailed
@@ -134,6 +143,39 @@ class PayrailsAPI {
         )
 
         return paymentStatus
+    }
+
+    /// Polls the execution URL until the workflow reaches an actual terminal authorization status
+    /// (`authorizeSuccessful` or `authorizeFailed`). Intended to run concurrently with the 3DS
+    /// WebView so that, if the WebView gets stuck or the backend redirect chain stalls, the SDK
+    /// can still discover the real outcome from the backend and resolve the payment.
+    func pollForTerminalDuringChallenge(executionUrl: URL) async throws -> PaymentStatus {
+        return try await checkExecutionStatus(
+            url: executionUrl,
+            targetStatuses: statusesAfterPending
+        )
+    }
+
+    /// Single, immediate read of the execution's current status — performs ONE plain
+    /// `getExecution` call with NO `waitWhile` long-poll and NO retry loop.
+    ///
+    /// This is the bounded counterpart to `pollForTerminalDuringChallenge` (which can block
+    /// for up to ~310s via `checkExecutionStatus`'s 10-attempt search + 300s long poll). The
+    /// 3DS swipe-dismiss confirmation window must resolve quickly so the button's loading
+    /// state can clear; it issues a few of these one-shot reads spaced ~1s apart instead of
+    /// awaiting the long poll.
+    ///
+    /// Returns the terminal `PaymentStatus` (`.success` / `.failed`) if the backend has
+    /// already reached one, or `nil` if the execution has not yet settled.
+    func fetchTerminalStatusOnce(executionUrl: URL) async throws -> PaymentStatus? {
+        let result = try await getExecution(url: executionUrl)
+        guard let terminal = result.sortedStatus.first(where: {
+            $0.code == PaymentAuthorizeStatus.authorizeSuccessful.rawValue ||
+            $0.code == PaymentAuthorizeStatus.authorizeFailed.rawValue
+        }) else {
+            return nil
+        }
+        return terminal.paymentStatus(with: result)
     }
 
     func confirmPaymentWithRetry(
@@ -526,7 +568,12 @@ private extension Status {
         case PayrailsAPI.PaymentAuthorizeStatus.authorizeSuccessful.rawValue:
             return .success
         case PayrailsAPI.PaymentAuthorizeStatus.authorizeFailed.rawValue:
-            return .failed
+            // Extract the failure message from the backend payload, falling back
+            // to a generic literal so callers never need to handle nil.
+            let message = self.errors?.first?.reason?.result
+                ?? self.errors?.first?.detail
+                ?? PayrailsAPI.genericAuthorizationFailedMessage
+            return .failed(message: message)
         case PayrailsAPI.PaymentAuthorizeStatus.authorizePending.rawValue:
             return .pending(executionResult)
         default:

--- a/Payrails/Classes/Public/Payrails.swift
+++ b/Payrails/Classes/Public/Payrails.swift
@@ -10,11 +10,13 @@ public class Payrails {
 
     static func createSession(
         with configuration: Payrails.Configuration,
+        onSessionExpired: SessionExpiredHandler? = nil,
         onInit: OnInitCallback
     ) {
         do {
             let payrailsSession = try Payrails.Session(
-                configuration
+                configuration,
+                onSessionExpired: onSessionExpired
             )
             currentSession = payrailsSession
             onInit(.success(payrailsSession))
@@ -34,10 +36,14 @@ public class Payrails {
 
 public extension Payrails {
     static func createSession(
-        with configuration: Payrails.Configuration
+        with configuration: Payrails.Configuration,
+        onSessionExpired: SessionExpiredHandler? = nil
     ) async throws -> Payrails.Session {
         let result = try await withCheckedThrowingContinuation({ continuation in
-            Payrails.createSession(with: configuration) { result in
+            Payrails.createSession(
+                with: configuration,
+                onSessionExpired: onSessionExpired
+            ) { result in
                 switch result {
                 case let .success(session):
                     continuation.resume(returning: session)

--- a/Payrails/Classes/Public/PayrailsSession.swift
+++ b/Payrails/Classes/Public/PayrailsSession.swift
@@ -14,6 +14,31 @@ public extension Payrails {
         private var currentTask: Task<Void, Error>?
         private var payrailsCSE: PayrailsCSE?
 
+        /// Runs in parallel with the 3DS WebView; whichever signal (WebView terminal URL or
+        /// backend terminal status) arrives first wins, guarded by `terminalReported`.
+        private var backgroundPollTask: Task<Void, Never>?
+
+        /// Single-shot guard ensuring the payment outcome is reported exactly once,
+        /// regardless of whether it arrives via the WebView delegate or background polling.
+        private var terminalReported = false
+        private let terminalLock = NSLock()
+
+        /// Captured at the start of the pending phase so the user-dismissed-3DS
+        /// confirmation poll knows which execution to query.
+        private var challengeExecutionUrl: URL?
+
+        /// Optional refresh handler supplied by the merchant at `createSession` time.
+        /// Invoked by `refreshIfPossible()` after the SDK detects the Payrails execution
+        /// is poisoned (e.g. user abandoned 3DS, no terminal confirmed) so the SDK can
+        /// rebuild its internal config in place without forcing the merchant to recreate
+        /// the `Session` and reassign it on every cached button / form.
+        private let onSessionExpired: SessionExpiredHandler?
+
+        /// Single-shot guard preventing overlapping refreshes. Cleared once the closure's
+        /// completion fires (whether success or failure).
+        private var isRefreshing = false
+        private let refreshLock = NSLock()
+
         var debugConfig: SDKConfig {
             return self.config
         }
@@ -25,9 +50,11 @@ public extension Payrails {
         }
 
         init(
-            _ configuration: Payrails.Configuration
+            _ configuration: Payrails.Configuration,
+            onSessionExpired: SessionExpiredHandler? = nil
         ) throws {
             self.option = configuration.option
+            self.onSessionExpired = onSessionExpired
             self.config = try parse(config: configuration)
 
             self.payrailsAPI = PayrailsAPI(config: config)
@@ -38,6 +65,10 @@ public extension Payrails {
                 self.payrailsCSE = try PayrailsCSE(data: configuration.initData.data, version: configuration.initData.version)
             } catch {
                 print("Failed to initialize PayrailsCSE:", error)
+            }
+
+            if onSessionExpired == nil {
+                Payrails.log("⚠️ No onSessionExpired handler provided to createSession. The SDK cannot self-heal if the user abandons a 3DS challenge — the next payment attempt against this Session will fail. See SessionExpiredHandler docs.")
             }
         }
 
@@ -102,6 +133,7 @@ public extension Payrails {
         ) {
             isPaymentInProgress = true
             self.onResult = onResult
+            resetTerminalGuard()
 
             guard prepareHandler(
                 for: instrument.type,
@@ -124,7 +156,6 @@ public extension Payrails {
                     "storeInstrument": false
                 ]
                 do {
-                    print("calling make payment")
                     let paymentStatus = try await strongSelf.payrailsAPI.makePayment(
                         type: instrument.type,
                         payload: body
@@ -147,6 +178,7 @@ public extension Payrails {
 
             isPaymentInProgress = true
             self.onResult = onResult
+            resetTerminalGuard()
 
             guard prepareHandler(
                 for: type,
@@ -159,7 +191,7 @@ public extension Payrails {
             }
 
             guard let total = Double(config.amount.value) else {
-                onResult(.error(.invalidDataFormat))
+                onResult(.authorizationFailed(.unknownError(.invalidDataFormat)))
                 isPaymentInProgress = false
                 return
             }
@@ -188,7 +220,7 @@ public extension Payrails {
 
             guard let paymentComposition = paymentComposition else {
                 isPaymentInProgress = false
-                onResult?(.error(.unsupportedPayment(type: type)))
+                onResult?(.authorizationFailed(.unknownError(.unsupportedPayment(type: type))))
                 return false
             }
 
@@ -204,7 +236,7 @@ public extension Payrails {
                     )
                     self.paymentHandler = payPalHandler
                 default:
-                    onResult?(.error(.incorrectPaymentSetup(type: type)))
+                    onResult?(.authorizationFailed(.unknownError(.incorrectPaymentSetup(type: type))))
                     return false
                 }
             case .applePay:
@@ -218,14 +250,14 @@ public extension Payrails {
                     self.paymentHandler = applePayHandler
                 default:
                     isPaymentInProgress = false
-                    onResult?(.error(.incorrectPaymentSetup(type: type)))
+                    onResult?(.authorizationFailed(.unknownError(.incorrectPaymentSetup(type: type))))
                     return false
                 }
             case .card:
                 guard let providerConfigId = config.vaultConfiguration?.providerConfigId,
                       !providerConfigId.isEmpty else {
                     isPaymentInProgress = false
-                    onResult?(.error(.missingData("Vault configuration with providerConfigId is required for card payments.")))
+                    onResult?(.authorizationFailed(.unknownError(.missingData("Vault configuration with providerConfigId is required for card payments."))))
                     return false
                 }
 
@@ -315,10 +347,20 @@ extension Payrails.Session: PaymentHandlerDelegate {
     ) {
         switch status {
         case .canceled:
+            // Backend-confirmed cancel: the issuer redirected to the cancel URL, so the
+            // execution reached a clean terminal. No session refresh needed — only the
+            // abandonment path (no backend terminal) leaves the execution reusable-but-pending.
+            // this will never happen based on backend polling.
+            guard claimTerminal() else { return }
+            cancelBackgroundPolling()
             isPaymentInProgress = false
-            onResult?(.cancelledByUser)
+            onResult?(.authorizationFailed(.userCancelled))
 
         case .success:
+            // Not yet terminal — the confirmation phase still has to run. But the background
+            // poll started during the pending phase would now race against the confirmation
+            // poll, so cancel it here.
+            cancelBackgroundPolling()
             handler.processSuccessPayload(
                 payload: payload,
                 amount: self.config.amount
@@ -349,9 +391,13 @@ extension Payrails.Session: PaymentHandlerDelegate {
             }
 
         case let .error(error):
+            // Clean terminal reached via the WebView error URL — the execution is closed,
+            // not left pending, so no refresh.
+            guard claimTerminal() else { return }
+            cancelBackgroundPolling()
             isPaymentInProgress = false
             let finalError = error ?? PayrailsError.unknown(error: nil)
-            onResult?(.error(finalError as! PayrailsError))
+            onResult?(.authorizationFailed(.unknownError(finalError as? PayrailsError)))
             onResult = nil
             paymentHandler = nil
         }
@@ -362,9 +408,81 @@ extension Payrails.Session: PaymentHandlerDelegate {
         error: PayrailsError,
         type: Payrails.PaymentType
     ) {
+        guard claimTerminal() else { return }
+        cancelBackgroundPolling()
         isPaymentInProgress = false
-        onResult?(.error(error))
+        onResult?(.authorizationFailed(.unknownError(error)))
         paymentHandler = nil
+    }
+
+    /// Called when the user interactively dismissed the 3DS challenge (e.g. swipe-down on
+    /// the modal). Two things to figure out before reporting an outcome:
+    ///
+    ///   1. Did the backend actually reach a terminal status that we just haven't
+    ///      observed yet? If yes, report that terminal — NOT a cancellation.
+    ///   2. If we genuinely can't confirm a terminal within a brief window, the user
+    ///      abandoned the flow and the execution is left in pending state on the backend.
+    ///      Emit `.authorizationFailed(.userCancelled)` and kick off the Session's in-place
+    ///      refresh via the merchant's `onSessionExpired` closure (the execution is
+    ///      reusable-but-pending, so the next attempt would otherwise be blocked).
+    ///
+    /// Uses a 6-attempt × 1s confirmation poll (per @kumaraksi's review on PR #78: a fixed
+    /// wait can give false negatives if backend reconciliation takes longer). Matches the
+    /// Web SDK's redirect-cancel pattern in `web-sdk/.../generic-redirect/index.ts:491-518`.
+    func paymentHandlerUserDidDismissChallenge(handler: PaymentHandler) {
+        let confirmationPollAttempts = 3
+        let confirmationPollInterval: UInt64 = 1_000_000_000   // 1 second
+
+        Task { [weak self] in
+            guard let self = self, let url = self.challengeExecutionUrl else {
+                // No execution URL captured — we can only fall through to declaring
+                // cancellation. Should not happen in practice (the URL is captured at
+                // startBackgroundPollingDuringChallenge time).
+                await MainActor.run { [weak self] in self?.emitUserCancelledAfterDismiss() }
+                return
+            }
+
+            for attempt in 1...confirmationPollAttempts {
+                if Task.isCancelled { return }
+                // Use the bounded one-shot read here — NOT pollForTerminalDuringChallenge,
+                // which can block for up to ~310s on its internal long poll and would leave
+                // the button spinning until it returns. The grace window must resolve in a
+                // few seconds so .userCancelled can be surfaced and the loading state cleared.
+                if let status = try? await self.payrailsAPI.fetchTerminalStatusOnce(executionUrl: url) {
+                    // The backend has reached a real terminal during the grace window.
+                    // Route it through the normal handler so the merchant sees the
+                    // ACTUAL outcome (success/failure with backend data), NOT a cancellation.
+                    await MainActor.run { [weak self] in
+                        self?.handleBackgroundPollTerminal(status: status)
+                    }
+                    return
+                }
+                if attempt < confirmationPollAttempts {
+                    try? await Task.sleep(nanoseconds: confirmationPollInterval)
+                }
+            }
+
+            // All attempts exhausted with no backend terminal — the user abandoned the flow
+            // and the execution remains pending. Surface .userCancelled and refresh.
+            await MainActor.run { [weak self] in self?.emitUserCancelledAfterDismiss() }
+        }
+    }
+
+    /// Single-shot terminal claim for the user-dismissed-with-no-resolution path.
+    /// Bails silently if the background poll already reported a real terminal.
+    ///
+    /// Surfaces `.authorizationFailed(.userCancelled)` to the caller, then fires
+    /// `refreshIfPossible()` because the execution is left non-terminal (pending) on the
+    /// backend — the merchant's next payment attempt would otherwise hit the dead execution.
+    private func emitUserCancelledAfterDismiss() {
+        guard claimTerminal() else { return }
+        cancelBackgroundPolling()
+        isPaymentInProgress = false
+        onResult?(.authorizationFailed(.userCancelled))
+        onResult = nil
+        paymentHandler = nil
+        // Non-terminal-left: refresh so the next attempt works against a fresh execution.
+        refreshIfPossible()
     }
 
     func paymentHandlerDidHandlePending(
@@ -380,7 +498,7 @@ extension Payrails.Session: PaymentHandlerDelegate {
 
         guard let link else {
             isPaymentInProgress = false
-            onResult?(.error(.missingData("Link response is missing")))
+            onResult?(.authorizationFailed(.unknownError(.missingData("Link response is missing"))))
             paymentHandler = nil
             return
         }
@@ -412,15 +530,201 @@ extension Payrails.Session: PaymentHandlerDelegate {
 
     private func handle(paymentStatus: PayrailsAPI.PaymentStatus) {
         switch paymentStatus {
-        case .failed:
-            onResult?(.failure)
+        case let .failed(message):
+            guard claimTerminal() else { return }
+            cancelBackgroundPolling()
+            onResult?(.authorizationFailed(.authorizationError(message: message)))
         case .success:
+            guard claimTerminal() else { return }
+            cancelBackgroundPolling()
             onResult?(.success)
         case let .pending(executionResult):
+            // Bail if a terminal has already been reported. Protects against late
+            // `.pending` arrivals (e.g. an in-flight `confirmPayment` task completing
+            // after the WebView / background poll already resolved the payment) firing
+            // stale `paymentHandlerWillRequestChallengePresentation` callbacks on the
+            // delegate — which would surface as a phantom `onThreeDSecureChallenge`
+            // after `onAuthorizeFailed` / `onAuthorizeSuccess`.
+            if isTerminalReported() { return }
+
+            // Branch on `actionRequired`:
+            //   - nil  → no action for the SDK to perform; surface `.pending` to the
+            //            caller so the merchant can poll / refresh / decide.
+            //   - else → perform the action (3DS challenge) and start the background
+            //            poll so we can resolve the payment even if the WebView stalls.
+            guard executionResult.actionRequired != nil else {
+                guard claimTerminal() else { return }
+                cancelBackgroundPolling()
+                // Backend pending with no action for the SDK. The execution is still live
+                // and may settle later, so surface `.pending` and do NOT refresh — refresh
+                // is reserved for non-terminal-left abandonment / timeout paths.
+                onResult?(.pending)
+                break
+            }
             paymentHandler?.handlePendingState(with: executionResult)
+            startBackgroundPollingDuringChallenge(executionResult: executionResult)
             return
         }
 
+        // `.failed` and `.success` are clean terminals — the execution is closed, not left
+        // pending, so no refresh here.
+        currentTask?.cancel()
+        currentTask = nil
+        isPaymentInProgress = false
+        onResult = nil
+        paymentHandler = nil
+    }
+
+    /// Single-shot guard: returns `true` only on the first call after each reset. Any subsequent
+    /// caller (e.g. WebView delegate firing after background polling already resolved the
+    /// payment) bails out without reporting a duplicate outcome.
+    private func claimTerminal() -> Bool {
+        terminalLock.lock()
+        defer { terminalLock.unlock() }
+        if terminalReported { return false }
+        terminalReported = true
+        return true
+    }
+
+    /// Lock-respecting read of the terminal-reported flag. Used by code paths that need
+    /// to bail when a terminal has already fired but do NOT want to claim it themselves
+    /// (e.g. a late `.pending` status that should not retrigger challenge presentation).
+    private func isTerminalReported() -> Bool {
+        terminalLock.lock()
+        defer { terminalLock.unlock() }
+        return terminalReported
+    }
+
+    private func resetTerminalGuard() {
+        terminalLock.lock()
+        terminalReported = false
+        terminalLock.unlock()
+    }
+
+    /// Self-heals the Session in place when the merchant supplied a refresh handler.
+    ///
+    /// Called only from paths that leave the Payrails execution non-terminal (pending),
+    /// where the next payment attempt against the cached `Session` would fail:
+    ///   - `emitUserCancelledAfterDismiss()` — user abandoned 3DS, confirmation poll found
+    ///     no terminal.
+    ///   - `handle(error:)` for a polling timeout or an expired token (HTTP 401 / 403).
+    /// Clean terminals (success, backend decline, cancel-URL) do NOT call this — the
+    /// execution is already closed there.
+    ///
+    /// Behaviour:
+    ///   - If no `onSessionExpired` handler was provided, this is a no-op (the
+    ///     warning was already logged at `Session.init` time).
+    ///   - If a refresh is already in flight, the second call is a no-op (guarded
+    ///     by `isRefreshing`).
+    ///   - On success: re-parse the fresh `InitData`, rebuild `config`,
+    ///     `payrailsAPI`, `payrailsCSE`, and `executionId` in place. The
+    ///     merchant's `Session` reference and every cached button/form keep
+    ///     working — only the underlying execution changes.
+    ///   - On failure: log and leave the Session as-is. The next payment tap will
+    ///     fail naturally with whatever the dead execution emits.
+    private func refreshIfPossible() {
+        guard let handler = onSessionExpired else { return }
+
+        refreshLock.lock()
+        if isRefreshing {
+            refreshLock.unlock()
+            return
+        }
+        isRefreshing = true
+        refreshLock.unlock()
+
+        handler { [weak self] result in
+            guard let self = self else { return }
+
+            DispatchQueue.main.async {
+                defer {
+                    self.refreshLock.lock()
+                    self.isRefreshing = false
+                    self.refreshLock.unlock()
+                }
+
+                switch result {
+                case let .success(newInitData):
+                    do {
+                        let newConfiguration = Payrails.Configuration(
+                            initData: newInitData,
+                            option: self.option
+                        )
+                        let newConfig = try self.parse(config: newConfiguration)
+                        self.config = newConfig
+                        self.payrailsAPI = PayrailsAPI(config: newConfig)
+                        self.executionId = newConfig.execution?.id
+                        do {
+                            self.payrailsCSE = try PayrailsCSE(
+                                data: newInitData.data,
+                                version: newInitData.version
+                            )
+                        } catch {
+                            Payrails.log("Session refresh: PayrailsCSE rebuild failed: \(error)")
+                        }
+                        Payrails.log("Session refreshed in place; new executionId=\(self.executionId ?? "<none>")")
+                    } catch {
+                        Payrails.log("Session refresh: parse failed: \(error)")
+                    }
+                case let .failure(error):
+                    Payrails.log("Session refresh handler reported failure: \(error)")
+                }
+            }
+        }
+    }
+
+    private func cancelBackgroundPolling() {
+        backgroundPollTask?.cancel()
+        backgroundPollTask = nil
+    }
+
+    /// Starts polling the workflow execution URL in parallel with the 3DS WebView. If the
+    /// backend reaches `authorizeSuccessful` / `authorizeFailed` before the WebView lands on a
+    /// recognized terminal URL (e.g. backend redirect chain stalls, network blip, unknown
+    /// return URL), polling will resolve the payment and dismiss the WebView. Otherwise the
+    /// WebView path wins and cancels this task.
+    private func startBackgroundPollingDuringChallenge(executionResult: GetExecutionResult) {
+        guard let url = URL(string: executionResult.links.`self`) else { return }
+        // Capture the URL for the user-dismissed-3DS confirmation poll path.
+        challengeExecutionUrl = url
+        cancelBackgroundPolling()
+        backgroundPollTask = Task { [weak self] in
+            guard let self = self else { return }
+            do {
+                let status = try await self.payrailsAPI.pollForTerminalDuringChallenge(executionUrl: url)
+                if Task.isCancelled { return }
+                await MainActor.run { [weak self] in
+                    self?.handleBackgroundPollTerminal(status: status)
+                }
+            } catch {
+                // Background poll could not resolve the payment (timed out, network error, etc.).
+                // Stay silent so the WebView path remains the primary resolution channel.
+                #if DEBUG
+                Payrails.log("Background polling ended without terminal: \(error)")
+                #endif
+            }
+        }
+    }
+
+    private func handleBackgroundPollTerminal(status: PayrailsAPI.PaymentStatus) {
+        // Only proceed if no terminal has been reported yet. If the WebView already resolved
+        // the payment, this call is a no-op.
+        guard claimTerminal() else { return }
+        paymentHandler?.dismissPresentedView()
+        // Route through the same handler that processes WebView-driven terminals so cleanup
+        // and `onResult` propagation are identical.
+        switch status {
+        case let .failed(message):
+            onResult?(.authorizationFailed(.authorizationError(message: message)))
+        case .success:
+            onResult?(.success)
+        case .pending:
+            // The polling target excludes `authorizePending`, so this branch should not occur.
+            // If it does, treat as no-op and let the WebView path drive.
+            return
+        }
+        // Background poll reached a clean terminal (`.success` / `.failed`) — the execution
+        // is closed, not left pending, so no refresh.
         currentTask?.cancel()
         currentTask = nil
         isPaymentInProgress = false
@@ -429,20 +733,49 @@ extension Payrails.Session: PaymentHandlerDelegate {
     }
 
     private func handle(error: Error) {
-        Payrails.log("Call handle payment withn error")
+        Payrails.log("Call handle payment with error")
+        guard claimTerminal() else { return }
+        cancelBackgroundPolling()
+
+        // `shouldRefresh` is true only when the execution is left non-terminal — i.e. the
+        // SDK gave up without the backend committing a terminal status. That covers an
+        // expired session token (401/403) and a polling timeout: in both cases the next
+        // attempt would target a dead/pending execution unless we refresh. Decode failures,
+        // missing data, and other hard errors are NOT refreshed.
+        let failure: AuthorizationFailure
+        var shouldRefresh = false
+
         if let payrailsError = error as? PayrailsError {
             switch payrailsError {
             case .authenticationError:
-                onResult?(.authorizationFailed)
+                // HTTP 401 / 403 — session token expired or invalid. Refreshing the session
+                // is precisely the remedy, so this joins the non-terminal-left refresh set.
+                failure = .authenticationError
+                shouldRefresh = true
+            case .pollingFailed, .finalStatusNotFoundAfterLongPoll, .longPollingFailed:
+                // The poll exhausted without a terminal — the backend never committed an
+                // outcome, leaving the execution pending. Honest code is `.unknownError`
+                // (the SDK genuinely doesn't know the result); refresh so a retry works.
+                failure = AuthorizationFailure(
+                    code: .unknownError,
+                    message: "The payment status could not be confirmed in time. Please try again.",
+                    rawError: payrailsError
+                )
+                shouldRefresh = true
             default:
-                onResult?(.error(payrailsError))
+                failure = .unknownError(payrailsError)
             }
         } else {
-            onResult?(.error(PayrailsError.unknown(error: error)))
+            failure = .unknownError(PayrailsError.unknown(error: error))
         }
+
+        onResult?(.authorizationFailed(failure))
         isPaymentInProgress = false
         onResult = nil
         paymentHandler = nil
+        if shouldRefresh {
+            refreshIfPossible()
+        }
     }
 }
 

--- a/Payrails/Classes/Public/Protocols/PaymentHandler.swift
+++ b/Payrails/Classes/Public/Protocols/PaymentHandler.swift
@@ -12,6 +12,15 @@ protocol PaymentHandler {
         amount: Amount,
         completion: @escaping (Result<[String: Any], Error>) -> Void
     )
+
+    /// Dismiss any user-facing view this handler has presented (e.g. a 3DS WebView).
+    /// Called when the session resolves the payment outcome from a source other than
+    /// the presented view (e.g. background polling discovered a terminal status first).
+    func dismissPresentedView()
+}
+
+extension PaymentHandler {
+    func dismissPresentedView() {}
 }
 
 // Add a default implementation

--- a/Payrails/Classes/Public/Protocols/PaymentHandlerDelegate.swift
+++ b/Payrails/Classes/Public/Protocols/PaymentHandlerDelegate.swift
@@ -20,6 +20,16 @@ protocol PaymentHandlerDelegate: AnyObject {
     )
 
     func paymentHandlerWillRequestChallengePresentation(_ handler: PaymentHandler)
+
+    /// Fired when the user interactively dismissed a presented challenge UI (e.g. swiping
+    /// down the 3DS modal). Implementations typically run a brief confirmation poll to
+    /// see if the backend has actually committed a terminal status, then report cancellation
+    /// if not.
+    func paymentHandlerUserDidDismissChallenge(handler: PaymentHandler)
+}
+
+extension PaymentHandlerDelegate {
+    func paymentHandlerUserDidDismissChallenge(handler: PaymentHandler) {}
 }
 
 enum PaymentHandlerStatus {

--- a/Payrails/Classes/Public/Views/ApplePayElement.swift
+++ b/Payrails/Classes/Public/Views/ApplePayElement.swift
@@ -79,16 +79,14 @@ public extension Payrails {
                             switch result {
                             case .success:
                                 self.delegate?.onAuthorizeSuccess(button)
+                            case let .authorizationFailed(failure) where failure.code == .userCancelled:
+                                self.delegate?.onPaymentSessionExpired(button)
                             case .authorizationFailed:
                                 self.delegate?.onAuthorizeFailed(button)
-                            case .failure:
-                                self.delegate?.onAuthorizeFailed(button)
-                            case let .error(error):
-                                self.delegate?.onAuthorizeFailed(button)
-                            case .cancelledByUser:
+                            case .pending:
                                 self.delegate?.onPaymentSessionExpired(button)
-                            default:
-                                print("Apple Pay payment result: \(String(describing: result))")
+                            case .none:
+                                print("Apple Pay payment result: nil")
                             }
                         }
 

--- a/Payrails/Classes/Public/Views/CardPaymentButton.swift
+++ b/Payrails/Classes/Public/Views/CardPaymentButton.swift
@@ -5,11 +5,26 @@ public protocol PayrailsCardPaymentButtonDelegate: AnyObject {
     func onPaymentButtonClicked(_ button: Payrails.CardPaymentButton)
     func onAuthorizeSuccess(_ button: Payrails.CardPaymentButton)
     func onThreeDSecureChallenge(_ button: Payrails.CardPaymentButton)
-    func onAuthorizeFailed(_ button: Payrails.CardPaymentButton)
+
+    /// Fires for every terminal failure of an authorization attempt. The `failure` carries a
+    /// `code` discriminating issuer decline, authentication error, user cancellation, and
+    /// other errors, plus a human-readable `message` and the underlying `rawError`. Mirrors
+    /// the Web SDK's `onFailed(action, { code, message, rawError })`.
+    ///
+    /// **Breaking change vs earlier iOS SDK versions** — the method now takes a `failure`
+    /// argument. See PR ONB-739 for migration notes.
+    func onAuthorizeFailed(_ button: Payrails.CardPaymentButton, failure: AuthorizationFailure)
+
+    /// Fires when the backend left the execution in a pending state with no action for the
+    /// SDK to perform. The payment is neither succeeded nor failed — it may settle later.
+    /// Default implementation is a no-op.
+    func onAuthorizePending(_ button: Payrails.CardPaymentButton)
+
     func onStoredInstrumentChanged(_ button: Payrails.CardPaymentButton, instrument: StoredInstrument?)
 }
 
 public extension PayrailsCardPaymentButtonDelegate {
+    func onAuthorizePending(_ button: Payrails.CardPaymentButton) {}
     func onStoredInstrumentChanged(_ button: Payrails.CardPaymentButton, instrument: StoredInstrument?) {}
 }
 
@@ -184,6 +199,7 @@ public extension Payrails {
         }
 
         @objc private func payButtonTapped() {
+            Payrails.log("CardPaymentButton.payButtonTapped fired (isProcessing=\(isProcessing), isUserInteractionEnabled=\(isUserInteractionEnabled), session=\(session != nil ? "present" : "nil"), cardForm=\(cardForm != nil ? "present" : "nil"))")
             delegate?.onPaymentButtonClicked(self)
 
             if let storedInstrument = storedInstrument {
@@ -208,15 +224,6 @@ public extension Payrails {
             }
 
             let paymentType = type ?? .card
-
-            if isStoredInstrumentMode {
-                print("🧩🧩🧩🧩🧩🧩🧩🧩🧩🧩")
-                print("pay with stored instrument")
-            } else {
-                print("-----------------------")
-                print("Save instrument:", self.cardForm?.saveInstrument ?? false)
-                print("-----------------------")
-            }
 
             paymentTask = Task { [weak self, weak session] in
                 await MainActor.run {
@@ -251,20 +258,21 @@ public extension Payrails {
             }
         }
 
-        private func handlePaymentResult(_ result: OnPayResult?) {
+        // internal (not private) so @testable tests can drive the result-routing
+        // logic directly. Not part of the public API surface.
+        internal func handlePaymentResult(_ result: OnPayResult?) {
             switch result {
             case .success:
                 delegate?.onAuthorizeSuccess(self)
-            case .authorizationFailed:
-                delegate?.onAuthorizeFailed(self)
-            case .failure:
-                delegate?.onAuthorizeFailed(self)
-            case .error:
-                delegate?.onAuthorizeFailed(self)
-            case .cancelledByUser:
-                Payrails.log("Payment was cancelled by user")
-            default:
-                Payrails.log("Payment result: unknown state")
+            case let .authorizationFailed(failure):
+                delegate?.onAuthorizeFailed(self, failure: failure)
+            case .pending:
+                // Backend left the execution pending with no action for the SDK to perform.
+                // The payment is not terminal — surface it as pending so the merchant can
+                // decide how to follow up.
+                delegate?.onAuthorizePending(self)
+            case .none:
+                Payrails.log("Payment result: nil")
             }
         }
 
@@ -293,6 +301,7 @@ public extension Payrails {
 // MARK: - PayrailsCardFormDelegate
 extension Payrails.CardPaymentButton: PayrailsCardFormDelegate {
     public func cardForm(_ view: Payrails.CardForm, didCollectCardData data: String) {
+        Payrails.log("CardPaymentButton.cardForm didCollectCardData (data length=\(data.count))")
         DispatchQueue.main.async { [weak self] in
             guard let self = self else { return }
 
@@ -305,6 +314,11 @@ extension Payrails.CardPaymentButton: PayrailsCardFormDelegate {
 
     public func cardForm(_ view: Payrails.CardForm, didFailWithError error: Error) {
         Payrails.log("Card collection failed: \(error.localizedDescription)")
-        // Could notify delegate here if needed
+        // Card collection / validation failure is not an authorization outcome — the form
+        // renders its own inline field errors. Just re-enable the button so the user can
+        // correct the input and retry; do not emit onAuthorizeFailed.
+        DispatchQueue.main.async { [weak self] in
+            self?.isProcessing = false
+        }
     }
 }

--- a/Payrails/Classes/Public/Views/CardPaymentForm.swift
+++ b/Payrails/Classes/Public/Views/CardPaymentForm.swift
@@ -6,7 +6,22 @@ public protocol PayrailsCardPaymentFormDelegate: AnyObject {
     func onPaymentButtonClicked(_ form: Payrails.CardPaymentForm)
     func onAuthorizeSuccess(_ form: Payrails.CardPaymentForm)
     func onThreeDSecureChallenge()
-    func onAuthorizeFailed(_ form: Payrails.CardPaymentForm)
+
+    /// Fires for every terminal failure of an authorization attempt. The `failure` carries a
+    /// `code`, human-readable `message`, and underlying `rawError`. See `AuthorizationFailure`
+    /// for the full taxonomy.
+    ///
+    /// **Breaking change vs earlier iOS SDK versions** — the method now takes a `failure`
+    /// argument.
+    func onAuthorizeFailed(_ form: Payrails.CardPaymentForm, failure: AuthorizationFailure)
+
+    /// Fires when the backend left the execution in a pending state with no action for the
+    /// SDK to perform. Default implementation is a no-op.
+    func onAuthorizePending(_ form: Payrails.CardPaymentForm)
+}
+
+public extension PayrailsCardPaymentFormDelegate {
+    func onAuthorizePending(_ form: Payrails.CardPaymentForm) {}
 }
 
 public extension Payrails {
@@ -152,20 +167,17 @@ public extension Payrails {
             }
         }
 
-        private func handlePaymentResult(_ result: OnPayResult?) {
+        // internal for @testable test drive — see CardPaymentButton.
+        internal func handlePaymentResult(_ result: OnPayResult?) {
             switch result {
             case .success:
                 delegate?.onAuthorizeSuccess(self)
-            case .authorizationFailed:
-                delegate?.onAuthorizeFailed(self)
-            case .failure:
-                delegate?.onAuthorizeFailed(self)
-            case let .error(error):
-                delegate?.onAuthorizeFailed(self)
-            case .cancelledByUser:
-                logMessage("Payment was cancelled by user")
-            default:
-                logMessage("Payment result: unknown state")
+            case let .authorizationFailed(failure):
+                delegate?.onAuthorizeFailed(self, failure: failure)
+            case .pending:
+                delegate?.onAuthorizePending(self)
+            case .none:
+                logMessage("Payment result: nil")
             }
         }
 

--- a/Payrails/Classes/Public/Views/GenericRedirectButton.swift
+++ b/Payrails/Classes/Public/Views/GenericRedirectButton.swift
@@ -10,8 +10,23 @@ import UIKit
 public protocol GenericRedirectPaymentButtonDelegate: AnyObject {
     func onPaymentButtonClicked(_ button: Payrails.GenericRedirectButton)
     func onAuthorizeSuccess(_ button: Payrails.GenericRedirectButton)
-    func onAuthorizeFailed(_ button: Payrails.GenericRedirectButton)
+
+    /// Fires for every terminal authorization failure. The `failure` carries a `code`,
+    /// human-readable `message`, and underlying `rawError`.
+    /// **Breaking change vs earlier versions.**
+    func onAuthorizeFailed(_ button: Payrails.GenericRedirectButton, failure: AuthorizationFailure)
+
+    /// Fires when the backend left the execution in a pending state with no action for the
+    /// SDK to perform. Default implementation is a no-op.
+    func onAuthorizePending(_ button: Payrails.GenericRedirectButton)
+
+    /// Legacy: payment-session-expired signal predating this redesign. Kept for
+    /// backward compatibility with existing GenericRedirect merchants.
     func onPaymentSessionExpired(_ button: Payrails.GenericRedirectButton)
+}
+
+public extension GenericRedirectPaymentButtonDelegate {
+    func onAuthorizePending(_ button: Payrails.GenericRedirectButton) {}
 }
 
 public extension Payrails {
@@ -109,20 +124,17 @@ public extension Payrails {
             }
         }
 
-        private func handlePaymentResult(_ result: OnPayResult?) {
+        // internal for @testable test drive — see CardPaymentButton.
+        internal func handlePaymentResult(_ result: OnPayResult?) {
             switch result {
             case .success:
                 delegate?.onAuthorizeSuccess(self)
-            case .authorizationFailed:
-                delegate?.onAuthorizeFailed(self)
-            case .failure:
-                delegate?.onAuthorizeFailed(self)
-            case .error:
-                delegate?.onAuthorizeFailed(self)
-            case .cancelledByUser:
-                Payrails.log("Payment was cancelled by user")
-            default:
-                Payrails.log("Payment result: unknown state")
+            case let .authorizationFailed(failure):
+                delegate?.onAuthorizeFailed(self, failure: failure)
+            case .pending:
+                delegate?.onAuthorizePending(self)
+            case .none:
+                Payrails.log("Payment result: nil")
             }
         }
     }

--- a/Payrails/Classes/Public/Views/PayWebViewController.swift
+++ b/Payrails/Classes/Public/Views/PayWebViewController.swift
@@ -12,6 +12,10 @@ internal class PayWebViewController: UIViewController {
     private let url: URL
     private let dismissalCallback: (() -> Void)?
 
+    /// Fired when the user interactively dismisses this view (e.g. swipe-down on iOS 13+
+    /// sheet presentation). NOT fired when the SDK dismisses the controller programmatically.
+    var onUserDismiss: (() -> Void)?
+
     init(url: URL, delegate: WKNavigationDelegate, dismissalCallback: (() -> Void)? = nil) {
         self.url = url
         self.dismissalCallback = dismissalCallback
@@ -39,5 +43,20 @@ internal class PayWebViewController: UIViewController {
         ])
 
         webView.load(.init(url: url, cachePolicy: .reloadIgnoringLocalCacheData))
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        // Receive the system's user-initiated dismissal callback (swipe-down on sheet
+        // presentations). Set here so we have a valid presentationController.
+        presentationController?.delegate = self
+    }
+}
+
+extension PayWebViewController: UIAdaptivePresentationControllerDelegate {
+    func presentationControllerDidDismiss(_ presentationController: UIPresentationController) {
+        // UIKit only invokes this when the user dismissed the sheet (not when we did it
+        // programmatically), so it is the right signal to surface as "user cancelled 3DS".
+        onUserDismiss?()
     }
 }

--- a/Payrails/Classes/Public/Views/PaypalElement.swift
+++ b/Payrails/Classes/Public/Views/PaypalElement.swift
@@ -58,11 +58,6 @@ public extension Payrails {
                 delegate?.onPaymentButtonClicked(button)
             }
 
-            print("--------------------")
-            print("save instrument: ", self.saveInstrument)
-            Payrails.log("save instrument: ", self.saveInstrument)
-            print("--------------------")
-
             paymentTask = Task { [weak self] in
                 guard let self = self else { return }
                 do {
@@ -79,16 +74,14 @@ public extension Payrails {
                             switch result {
                             case .success:
                                 self.delegate?.onAuthorizeSuccess(button)
+                            case let .authorizationFailed(failure) where failure.code == .userCancelled:
+                                self.delegate?.onPaymentSessionExpired(button)
                             case .authorizationFailed:
                                 self.delegate?.onAuthorizeFailed(button)
-                            case .failure:
-                                self.delegate?.onAuthorizeFailed(button)
-                            case let .error(error):
-                                self.delegate?.onAuthorizeFailed(button)
-                            case .cancelledByUser:
+                            case .pending:
                                 self.delegate?.onPaymentSessionExpired(button)
-                            default:
-                                print("PayPal payment result: \(String(describing: result))")
+                            case .none:
+                                print("PayPal payment result: nil")
                             }
                         }
 

--- a/Payrails/Classes/Public/Views/StoredInstrumentPaymentButton.swift
+++ b/Payrails/Classes/Public/Views/StoredInstrumentPaymentButton.swift
@@ -4,7 +4,19 @@ import UIKit
 public protocol PayrailsStoredInstrumentPaymentButtonDelegate: AnyObject {
     func onPaymentButtonClicked(_ button: Payrails.StoredInstrumentPaymentButton)
     func onAuthorizeSuccess(_ button: Payrails.StoredInstrumentPaymentButton)
-    func onAuthorizeFailed(_ button: Payrails.StoredInstrumentPaymentButton)
+
+    /// Fires for every terminal authorization failure. The `failure` carries a `code`,
+    /// human-readable `message`, and underlying `rawError`.
+    /// **Breaking change vs earlier versions.**
+    func onAuthorizeFailed(_ button: Payrails.StoredInstrumentPaymentButton, failure: AuthorizationFailure)
+
+    /// Fires when the backend left the execution in a pending state with no action for the
+    /// SDK to perform. Default implementation is a no-op.
+    func onAuthorizePending(_ button: Payrails.StoredInstrumentPaymentButton)
+}
+
+public extension PayrailsStoredInstrumentPaymentButtonDelegate {
+    func onAuthorizePending(_ button: Payrails.StoredInstrumentPaymentButton) {}
 }
 
 public struct StoredInstrumentButtonTranslations {
@@ -136,8 +148,6 @@ public extension Payrails {
                 Payrails.log("Session not available")
                 return
             }
-            print("🧩🧩🧩🧩🧩🧩🧩🧩🧩🧩")
-            print("pay with stored instrument")
 
             paymentTask = Task { [weak self, weak session] in
                 await MainActor.run {
@@ -159,20 +169,17 @@ public extension Payrails {
             }
         }
 
-        private func handlePaymentResult(_ result: OnPayResult?) {
+        // internal for @testable test drive — see CardPaymentButton.
+        internal func handlePaymentResult(_ result: OnPayResult?) {
             switch result {
             case .success:
                 delegate?.onAuthorizeSuccess(self)
-            case .authorizationFailed:
-                delegate?.onAuthorizeFailed(self)
-            case .failure:
-                delegate?.onAuthorizeFailed(self)
-            case .error:
-                delegate?.onAuthorizeFailed(self)
-            case .cancelledByUser:
-                Payrails.log("Payment was cancelled by user")
-            default:
-                Payrails.log("Payment result: unknown state")
+            case let .authorizationFailed(failure):
+                delegate?.onAuthorizeFailed(self, failure: failure)
+            case .pending:
+                delegate?.onAuthorizePending(self)
+            case .none:
+                Payrails.log("Payment result: nil")
             }
         }
 

--- a/Payrails/Classes/Public/Views/StoredInstrumentView.swift
+++ b/Payrails/Classes/Public/Views/StoredInstrumentView.swift
@@ -286,9 +286,10 @@ extension Payrails.StoredInstrumentView: PayrailsCardPaymentButtonDelegate {
         Payrails.log("3DS challenge called for stored instrument (unexpected)")
     }
 
-    public func onAuthorizeFailed(_ button: Payrails.CardPaymentButton) {
-        // Create a generic error since we don't have specific error details
-        let error = PayrailsError.authenticationError
+    public func onAuthorizeFailed(_ button: Payrails.CardPaymentButton, failure: AuthorizationFailure) {
+        // The legacy storedInstrumentView delegate API surfaces a single PayrailsError.
+        // Prefer the underlying error when present, otherwise fall back to a generic one.
+        let error = (failure.rawError as? PayrailsError) ?? PayrailsError.unknown(error: failure.rawError)
         delegate?.storedInstrumentView(self, didFailPaymentForInstrument: instrument, error: error)
     }
 }

--- a/PayrailsTests/PayrailsTests.swift
+++ b/PayrailsTests/PayrailsTests.swift
@@ -7,6 +7,7 @@
 
 import XCTest
 import UIKit
+import WebKit
 @testable import Payrails
 
 final class PayrailsTests: XCTestCase {
@@ -2060,14 +2061,26 @@ final class PayrailsTests: XCTestCase {
     private class MockCardPaymentButtonDelegate: PayrailsCardPaymentButtonDelegate {
         var onStoredInstrumentChangedCalled = false
         var onPaymentButtonClickedCalled = false
+        var onAuthorizeSuccessCalled = false
+        var onAuthorizeFailedCalled = false
+        var onAuthorizePendingCalled = false
+        var lastAuthorizeFailure: AuthorizationFailure?
         var lastInstrumentId: String?
 
         func onPaymentButtonClicked(_ button: Payrails.CardPaymentButton) {
             onPaymentButtonClickedCalled = true
         }
-        func onAuthorizeSuccess(_ button: Payrails.CardPaymentButton) {}
+        func onAuthorizeSuccess(_ button: Payrails.CardPaymentButton) {
+            onAuthorizeSuccessCalled = true
+        }
         func onThreeDSecureChallenge(_ button: Payrails.CardPaymentButton) {}
-        func onAuthorizeFailed(_ button: Payrails.CardPaymentButton) {}
+        func onAuthorizeFailed(_ button: Payrails.CardPaymentButton, failure: AuthorizationFailure) {
+            onAuthorizeFailedCalled = true
+            lastAuthorizeFailure = failure
+        }
+        func onAuthorizePending(_ button: Payrails.CardPaymentButton) {
+            onAuthorizePendingCalled = true
+        }
 
         func onStoredInstrumentChanged(_ button: Payrails.CardPaymentButton, instrument: StoredInstrument?) {
             onStoredInstrumentChangedCalled = true
@@ -2079,8 +2092,9 @@ final class PayrailsTests: XCTestCase {
         func onPaymentButtonClicked(_ button: Payrails.CardPaymentButton) {}
         func onAuthorizeSuccess(_ button: Payrails.CardPaymentButton) {}
         func onThreeDSecureChallenge(_ button: Payrails.CardPaymentButton) {}
-        func onAuthorizeFailed(_ button: Payrails.CardPaymentButton) {}
-        // Intentionally NOT implementing onStoredInstrumentChanged — uses default extension
+        func onAuthorizeFailed(_ button: Payrails.CardPaymentButton, failure: AuthorizationFailure) {}
+        // Intentionally NOT implementing onAuthorizePending / onStoredInstrumentChanged —
+        // both use the default extension; the delegate must still satisfy the protocol.
     }
 
     // MARK: - UpdateOptions Tests
@@ -2670,4 +2684,364 @@ final class PayrailsTests: XCTestCase {
         XCTAssertEqual(cvvLeading ?? .nan, 8, accuracy: 0.001,
                        "CVV field should use its own fieldInsets.left (8)")
     }
+
+    // MARK: - ONB-739: failure callback redesign — AuthorizationFailure + refresh-closure
+    //
+    // These tests verify the public protocol surface after the redesign:
+    //   * `onAuthorizeFailed` now takes a `failure: AuthorizationFailure` ({code, message,
+    //     rawError}), matching the Web SDK's `onFailed(action, { code, message, rawError })`.
+    //   * `.pending` surfaces via the dedicated `onAuthorizePending` callback, NOT as a
+    //     failure.
+    //   * Session refresh on a non-terminal-left execution is owned by the SDK via the
+    //     `onSessionExpired` closure passed to `createSession`, NOT by a per-button
+    //     delegate method.
+    //
+    // End-to-end orchestration tests (concurrent polling resolution, race-condition
+    // arbitration via `claimTerminal()`, the 6s grace window after user-dismiss) require
+    // URLProtocol-based mocking of `URLSession.shared` which the current test target does
+    // not have. Those should be added in a follow-up that introduces a `MockURLProtocol`
+    // helper.
+
+    func testCardPaymentButtonDelegate_onAuthorizeFailed_carriesUserCancelledReason() {
+        let delegate = MockCardPaymentButtonDelegate()
+        let button = Payrails.CardPaymentButton(translations: CardPaymenButtonTranslations(label: "Pay"))
+        delegate.onAuthorizeFailed(button, failure: .userCancelled)
+        XCTAssertTrue(delegate.onAuthorizeFailedCalled)
+        XCTAssertEqual(delegate.lastAuthorizeFailure?.code, .userCancelled)
+    }
+
+    func testCardPaymentButtonDelegate_onAuthorizeFailed_carriesAuthorizationErrorReasonWithMessage() {
+        let delegate = MockCardPaymentButtonDelegate()
+        let button = Payrails.CardPaymentButton(translations: CardPaymenButtonTranslations(label: "Pay"))
+        delegate.onAuthorizeFailed(button, failure: .authorizationError(message: "ParamsError"))
+        XCTAssertEqual(delegate.lastAuthorizeFailure?.code, .authorizationError)
+        XCTAssertEqual(delegate.lastAuthorizeFailure?.message, "ParamsError",
+                       "Backend-extracted message should survive through the delegate")
+    }
+
+    func testStatus_extractsAuthorizeFailedMessageFromBackendErrors() throws {
+        // Build the JSON shape staging returns when authorizeFailed includes an `errors`
+        // array, and verify the message extraction logic threads the backend's
+        // `reason.result` through to the merchant-facing payload.
+        let json = Data("""
+        {
+          "id": "exec-1",
+          "status": [
+            {
+              "code": "authorizeFailed",
+              "time": "2026-05-19T16:49:09.342504587Z",
+              "errors": [
+                {
+                  "id": "err-1",
+                  "code": "workflow.action.failed",
+                  "detail": "The execution of the requested workflow action failed",
+                  "docUrl": "https://docs.payrails.com/docs/error-codes#workflowactionfailed",
+                  "reason": {
+                    "category": "Configuration",
+                    "result": "ParamsError",
+                    "source": "Merchant"
+                  }
+                }
+              ]
+            }
+          ],
+          "createdAt": "2026-05-19T16:48:48.522393522Z",
+          "merchantReference": "order-x",
+          "holderReference": "holder-x",
+          "workflow": { "code": "payment-acceptance", "version": 67 },
+          "links": { "self": "https://example.com/exec/1" }
+        }
+        """.utf8)
+        let decoded = try JSONDecoder.API().decode(GetExecutionResult.self, from: json)
+        let authorizeFailedEntry = try XCTUnwrap(
+            decoded.sortedStatus.first(where: { $0.code == "authorizeFailed" })
+        )
+        XCTAssertEqual(authorizeFailedEntry.errors?.first?.reason?.result, "ParamsError",
+                       "Status model must decode the backend's errors[0].reason.result so the SDK can surface it as the authorizationError message")
+        XCTAssertEqual(authorizeFailedEntry.errors?.first?.code, "workflow.action.failed")
+        XCTAssertEqual(authorizeFailedEntry.errors?.first?.detail,
+                       "The execution of the requested workflow action failed")
+    }
+
+    func testStatus_authorizeFailedWithNoErrorsDecodesCleanly() throws {
+        // Status entries without an `errors` array (success states, pending states, or
+        // legacy responses) must still decode. The extraction logic falls back to the
+        // generic message; here we just verify decoding does not throw.
+        let json = Data("""
+        {
+          "id": "exec-2",
+          "status": [
+            { "code": "authorizeSuccessful", "time": "2026-05-19T16:49:09Z" }
+          ],
+          "createdAt": "2026-05-19T16:48:48Z",
+          "merchantReference": "order-y",
+          "holderReference": "holder-y",
+          "workflow": { "code": "payment-acceptance", "version": 67 },
+          "links": { "self": "https://example.com/exec/2" }
+        }
+        """.utf8)
+        let decoded = try JSONDecoder.API().decode(GetExecutionResult.self, from: json)
+        XCTAssertNil(decoded.sortedStatus.first?.errors,
+                     "Status without errors field must decode with errors == nil")
+    }
+
+    func testCardPaymentButtonDelegate_onAuthorizeFailed_carriesUnknownErrorWithPayload() {
+        let delegate = MockCardPaymentButtonDelegate()
+        let button = Payrails.CardPaymentButton(translations: CardPaymenButtonTranslations(label: "Pay"))
+        let underlying = PayrailsError.missingData("network blip")
+        delegate.onAuthorizeFailed(button, failure: .unknownError(underlying))
+        XCTAssertEqual(delegate.lastAuthorizeFailure?.code, .unknownError)
+        XCTAssertNotNil(delegate.lastAuthorizeFailure?.rawError,
+                        "PayrailsError payload should survive through the delegate as rawError")
+    }
+
+    // MARK: - ONB-739: handlePaymentResult routing
+    //
+    // These tests pin down the delegate routing in each button's handlePaymentResult:
+    //   * `.success` → only `onAuthorizeSuccess`
+    //   * `.authorizationFailed(failure)` → only `onAuthorizeFailed` with the failure
+    //   * `.pending` → only `onAuthorizePending` (backend pending, no SDK action).
+
+    func testHandlePaymentResult_success_doesNotFireSessionExpired() {
+        let delegate = MockCardPaymentButtonDelegate()
+        let button = Payrails.CardPaymentButton(translations: CardPaymenButtonTranslations(label: "Pay"))
+        button.delegate = delegate
+        button.handlePaymentResult(.success)
+        XCTAssertTrue(delegate.onAuthorizeSuccessCalled)
+    }
+
+    func testHandlePaymentResult_authorizationError_firesAuthorizeFailed() {
+        // Backend confirmed `authorizeFailed` and gave us a message. Execution is
+        // closed; SDK must surface the failure verbatim.
+        let delegate = MockCardPaymentButtonDelegate()
+        let button = Payrails.CardPaymentButton(translations: CardPaymenButtonTranslations(label: "Pay"))
+        button.delegate = delegate
+        button.handlePaymentResult(.authorizationFailed(.authorizationError(message: "ParamsError")))
+        XCTAssertTrue(delegate.onAuthorizeFailedCalled,
+                      "Terminal backend failure must fire onAuthorizeFailed")
+        XCTAssertEqual(delegate.lastAuthorizeFailure?.code, .authorizationError)
+        XCTAssertEqual(delegate.lastAuthorizeFailure?.message, "ParamsError")
+    }
+
+    func testHandlePaymentResult_unknownError_firesAuthorizeFailed() {
+        // Network / SDK error. State of the backend execution is ambiguous.
+        let delegate = MockCardPaymentButtonDelegate()
+        let button = Payrails.CardPaymentButton(translations: CardPaymenButtonTranslations(label: "Pay"))
+        button.delegate = delegate
+        button.handlePaymentResult(.authorizationFailed(.unknownError(.unknown(error: nil))))
+        XCTAssertTrue(delegate.onAuthorizeFailedCalled)
+        XCTAssertEqual(delegate.lastAuthorizeFailure?.code, .unknownError)
+    }
+
+    func testHandlePaymentResult_userCancelled_firesAuthorizeFailed() {
+        // Backend confirmed cancel via the `payrails-cancel.html` URL.
+        let delegate = MockCardPaymentButtonDelegate()
+        let button = Payrails.CardPaymentButton(translations: CardPaymenButtonTranslations(label: "Pay"))
+        button.delegate = delegate
+        button.handlePaymentResult(.authorizationFailed(.userCancelled))
+        XCTAssertTrue(delegate.onAuthorizeFailedCalled)
+        XCTAssertEqual(delegate.lastAuthorizeFailure?.code, .userCancelled,
+                       "Backend-confirmed cancel must surface as .userCancelled")
+    }
+
+    func testHandlePaymentResult_pending_firesOnlyAuthorizePending() {
+        // `.pending` (backend pending, no actionRequired) routes to the dedicated
+        // onAuthorizePending callback — NOT to onAuthorizeFailed. No session refresh.
+        let delegate = MockCardPaymentButtonDelegate()
+        let button = Payrails.CardPaymentButton(translations: CardPaymenButtonTranslations(label: "Pay"))
+        button.delegate = delegate
+        button.handlePaymentResult(.pending)
+        XCTAssertTrue(delegate.onAuthorizePendingCalled,
+                      "Pending must surface via onAuthorizePending")
+        XCTAssertFalse(delegate.onAuthorizeFailedCalled,
+                       "Pending must NOT surface as a failure")
+    }
+
+    func testCardPaymentFormDelegate_redesignedSurfaceCompiles() {
+        // Verifies that a CardPaymentForm delegate matching the redesigned protocol
+        // surface compiles: `onAuthorizeFailed(_:failure:)` is required; `onAuthorizePending`
+        // is optional (default no-op).
+        final class MinimalFormDelegate: PayrailsCardPaymentFormDelegate {
+            func onPaymentButtonClicked(_ form: Payrails.CardPaymentForm) {}
+            func onAuthorizeSuccess(_ form: Payrails.CardPaymentForm) {}
+            func onThreeDSecureChallenge() {}
+            func onAuthorizeFailed(_ form: Payrails.CardPaymentForm, failure: AuthorizationFailure) {}
+        }
+        _ = MinimalFormDelegate()
+    }
+
+    func testStoredInstrumentPaymentButtonDelegate_redesignedSurfaceCompiles() {
+        final class MinimalStoredDelegate: PayrailsStoredInstrumentPaymentButtonDelegate {
+            func onPaymentButtonClicked(_ button: Payrails.StoredInstrumentPaymentButton) {}
+            func onAuthorizeSuccess(_ button: Payrails.StoredInstrumentPaymentButton) {}
+            func onAuthorizeFailed(_ button: Payrails.StoredInstrumentPaymentButton, failure: AuthorizationFailure) {}
+        }
+        _ = MinimalStoredDelegate()
+    }
+
+    func testGenericRedirectPaymentButtonDelegate_redesignedSurfaceCompiles() {
+        final class MinimalRedirectDelegate: GenericRedirectPaymentButtonDelegate {
+            func onPaymentButtonClicked(_ button: Payrails.GenericRedirectButton) {}
+            func onAuthorizeSuccess(_ button: Payrails.GenericRedirectButton) {}
+            func onAuthorizeFailed(_ button: Payrails.GenericRedirectButton, failure: AuthorizationFailure) {}
+            func onPaymentSessionExpired(_ button: Payrails.GenericRedirectButton) {}
+        }
+        _ = MinimalRedirectDelegate()
+    }
+
+    // MARK: - ONB-739: AuthorizationFailure code raw-value parity with Web SDK
+
+    func testAuthorizationFailureReason_rawValuesMatchWebSDK() {
+        XCTAssertEqual(AuthorizationFailureReason.authorizationError.rawValue, "AUTHORIZATION_ERROR")
+        XCTAssertEqual(AuthorizationFailureReason.authenticationError.rawValue, "AUTHENTICATION_ERROR")
+        XCTAssertEqual(AuthorizationFailureReason.userCancelled.rawValue, "USER_CANCELLED")
+        XCTAssertEqual(AuthorizationFailureReason.unknownError.rawValue, "UNKNOWN_ERROR")
+    }
+
+    func testAuthorizationFailure_staticHelpers_setExpectedCodes() {
+        XCTAssertEqual(AuthorizationFailure.userCancelled.code, .userCancelled)
+        XCTAssertEqual(AuthorizationFailure.authenticationError.code, .authenticationError)
+        XCTAssertEqual(AuthorizationFailure.authorizationError(message: "x").code, .authorizationError)
+        XCTAssertEqual(AuthorizationFailure.authorizationError(message: "x").message, "x")
+
+        let underlying = PayrailsError.missingData("boom")
+        let unknown = AuthorizationFailure.unknownError(underlying)
+        XCTAssertEqual(unknown.code, .unknownError)
+        XCTAssertNotNil(unknown.rawError, "unknownError must preserve the underlying error")
+    }
+
+    // MARK: - ONB-739: SessionExpiredHandler refresh closure
+    //
+    // Pins down the contract: the closure type compiles, is callable, and accepts
+    // both `.success(InitData)` and `.failure(Error)` completions. End-to-end
+    // verification that the SDK invokes the closure on `.pending` and swaps its
+    // config in place requires the URLProtocol-based mock harness mentioned above.
+
+    func testSessionExpiredHandler_compilesAsCompletionStyleClosure() {
+        // The merchant's typical integration: fetch new init payload from their
+        // backend, call completion with .success(InitData).
+        let handler: SessionExpiredHandler = { completion in
+            let fresh = Payrails.InitData(version: "test-v1", data: "freshBase64Data")
+            completion(.success(fresh))
+        }
+        var receivedInitData: Payrails.InitData?
+        handler { result in
+            if case let .success(initData) = result {
+                receivedInitData = initData
+            }
+        }
+        XCTAssertEqual(receivedInitData?.version, "test-v1",
+                       "Refresh closure must surface the merchant-supplied InitData")
+        XCTAssertEqual(receivedInitData?.data, "freshBase64Data")
+    }
+
+    func testSessionExpiredHandler_supportsFailureCompletion() {
+        // If the merchant's backend fetch fails, the closure can report it. The
+        // SDK logs the failure and leaves the Session as-is (next Pay tap will
+        // fail naturally against the dead execution).
+        struct FetchFailed: Error {}
+        let handler: SessionExpiredHandler = { completion in
+            completion(.failure(FetchFailed()))
+        }
+        var receivedFailure = false
+        handler { result in
+            if case .failure = result { receivedFailure = true }
+        }
+        XCTAssertTrue(receivedFailure,
+                      "Refresh closure must support reporting backend-fetch failures")
+    }
+
+    // MARK: - ONB-739: PayWebViewController user-dismiss detection
+
+    func testPayWebViewController_presentationControllerDidDismiss_invokesOnUserDismiss() {
+        // When UIKit notifies the controller that the user interactively dismissed the
+        // sheet, the view controller must invoke the onUserDismiss callback so the
+        // session can surface OnPayResult.pending (or a backend-confirmed terminal).
+        let url = URL(string: "https://example.com")!
+        let dummyDelegate = DummyNavigationDelegate()
+        let vc = PayWebViewController(url: url, delegate: dummyDelegate)
+        var dismissed = false
+        vc.onUserDismiss = { dismissed = true }
+
+        // Stand-in presentation controller for the delegate-method argument; the SDK
+        // implementation does not inspect it.
+        let standInPresentation = UIPresentationController(presentedViewController: vc, presenting: nil)
+        vc.presentationControllerDidDismiss(standInPresentation)
+
+        XCTAssertTrue(dismissed,
+                      "presentationControllerDidDismiss(_:) must trigger the onUserDismiss callback")
+    }
+
+    func testPayWebViewController_presentationControllerDidDismiss_safeWhenCallbackUnset() {
+        // If a caller never sets onUserDismiss (e.g. some internal code path), the
+        // dismissal notification must not crash. This guards against future regressions
+        // that try to force-unwrap the optional.
+        let url = URL(string: "https://example.com")!
+        let dummyDelegate = DummyNavigationDelegate()
+        let vc = PayWebViewController(url: url, delegate: dummyDelegate)
+
+        let standInPresentation = UIPresentationController(presentedViewController: vc, presenting: nil)
+        vc.presentationControllerDidDismiss(standInPresentation)
+        // No assertion needed — reaching this line without crash is the proof.
+    }
+
+    // MARK: - ONB-739: PaymentHandler protocol default extensions
+
+    func testPaymentHandlerProtocol_dismissPresentedView_defaultIsNoOp() {
+        // A handler that does not override dismissPresentedView() must still satisfy the
+        // protocol and the default empty implementation must execute without crashing.
+        final class MinimalHandler: PaymentHandler {
+            func makePayment(total: Double, currency: String, presenter: PaymentPresenter?) {}
+            func handlePendingState(with: GetExecutionResult) {}
+            func processSuccessPayload(
+                payload: [String: Any]?,
+                amount: Amount,
+                completion: @escaping (Result<[String: Any], Error>) -> Void
+            ) {}
+            // Intentionally no dismissPresentedView override.
+        }
+        let handler: PaymentHandler = MinimalHandler()
+        handler.dismissPresentedView()
+    }
+
+    func testPaymentHandlerDelegate_paymentHandlerUserDidDismissChallenge_defaultIsNoOp() {
+        // A delegate that does not override the new user-dismiss method must still
+        // satisfy the protocol via the default extension and execute as a no-op.
+        final class MinimalDelegate: PaymentHandlerDelegate {
+            func paymentHandlerDidFinish(
+                handler: PaymentHandler,
+                type: Payrails.PaymentType,
+                status: PaymentHandlerStatus,
+                payload: [String: Any]?
+            ) {}
+            func paymentHandlerDidFail(
+                handler: PaymentHandler,
+                error: PayrailsError,
+                type: Payrails.PaymentType
+            ) {}
+            func paymentHandlerDidHandlePending(
+                handler: PaymentHandler,
+                type: Payrails.PaymentType,
+                link: Link?,
+                payload: [String: Any]?
+            ) {}
+            func paymentHandlerWillRequestChallengePresentation(_ handler: PaymentHandler) {}
+            // Intentionally no paymentHandlerUserDidDismissChallenge override.
+        }
+        final class StubHandler: PaymentHandler {
+            func makePayment(total: Double, currency: String, presenter: PaymentPresenter?) {}
+            func handlePendingState(with: GetExecutionResult) {}
+            func processSuccessPayload(
+                payload: [String: Any]?,
+                amount: Amount,
+                completion: @escaping (Result<[String: Any], Error>) -> Void
+            ) {}
+        }
+        let delegate: PaymentHandlerDelegate = MinimalDelegate()
+        delegate.paymentHandlerUserDidDismissChallenge(handler: StubHandler())
+    }
 }
+
+// Lightweight WKNavigationDelegate stub used only to satisfy PayWebViewController's
+// initializer in tests; it intentionally performs no navigation handling.
+private final class DummyNavigationDelegate: NSObject, WKNavigationDelegate {}

--- a/docs/card-payment-flow-documentation.md
+++ b/docs/card-payment-flow-documentation.md
@@ -185,15 +185,18 @@ struct CardFormConfig {
 func pay(with type: PaymentType?, storedInstrument: StoredInstrument?)
 ```
 
-**Delegate Protocol**:
+**Delegate Protocol** (as of ONB-739):
 ```swift
 protocol PayrailsCardPaymentButtonDelegate: AnyObject {
     func onPaymentButtonClicked(_ button: CardPaymentButton)
     func onAuthorizeSuccess(_ button: CardPaymentButton)
+    func onAuthorizePending(_ button: CardPaymentButton)
     func onThreeDSecureChallenge(_ button: CardPaymentButton)
-    func onAuthorizeFailed(_ button: CardPaymentButton)
+    func onAuthorizeFailed(_ button: CardPaymentButton, failure: AuthorizationFailure)
 }
 ```
+
+`AuthorizationFailure` carries `code: AuthorizationFailureReason`, `message: String` (backend-extracted, with generic fallback, never nil), and `rawError: Error?`. The four `code` values: `.userCancelled`, `.authorizationError`, `.authenticationError`, `.unknownError`. Session refresh after a poisoned execution is driven by the `onSessionExpired` closure supplied at `Payrails.createSession(with:onSessionExpired:)` time — NOT a per-button delegate method. See [public/sdk-api-reference.md](public/sdk-api-reference.md).
 
 ### 4. CardPaymentHandler
 
@@ -404,19 +407,33 @@ extension ViewController: PayrailsCardPaymentButtonDelegate {
     func onPaymentButtonClicked(_ button: CardPaymentButton) {
         // Handle payment initiation
     }
-    
+
     func onAuthorizeSuccess(_ button: CardPaymentButton) {
         // Handle successful payment
     }
-    
+
     func onThreeDSecureChallenge(_ button: CardPaymentButton) {
         // Handle 3DS challenge presentation
     }
-    
-    func onAuthorizeFailed(_ button: CardPaymentButton) {
-        // Handle payment failure
+
+    func onAuthorizeFailed(_ button: CardPaymentButton, failure: AuthorizationFailure) {
+        switch failure.code {
+        case .userCancelled:        // user dismissed the 3DS sheet
+            break
+        case .authorizationError:   // issuer declined / 3DS rejected
+            _ = failure.message     // backend-extracted reason (never nil)
+        case .authenticationError:  // session token rejected (401 / 403)
+            break
+        case .unknownError:         // network / SDK / unexpected
+            _ = failure.rawError
+        }
     }
 }
+
+// Session refresh after a poisoned execution is configured at session creation:
+//   Payrails.createSession(with: configuration, onSessionExpired: { completion in
+//       myBackend.fetchPayrailsInit { result in completion(result) }
+//   })
 
 extension ViewController: PaymentPresenter {
     func presentPayment(_ viewController: UIViewController) {

--- a/docs/internal/architecture.md
+++ b/docs/internal/architecture.md
@@ -215,10 +215,14 @@ SDK calls authorize API
         │                              SDK polls for result
         │                                    │
         │                              ├──── Success ──► onAuthorizeSuccess
-        │                              └──── Failure ──► onAuthorizeFailed
+        │                              └──── Failure ──► onAuthorizeFailed(_:failure:)
+        │                                                (+ onSessionExpired closure if execution left pending)
         │
-        └──── Failure ──────────────► onAuthorizeFailed
+        └──── Failure ──────────────► onAuthorizeFailed(_:failure:)
+                                       (+ onSessionExpired closure if execution left pending)
 ```
+
+The `failure` argument is an `AuthorizationFailure` struct with `code: AuthorizationFailureReason`, `message: String`, and `rawError: Error?`. The four `code` values (raw values match the Web SDK 1:1): `.authorizationError` (issuer declined / 3DS rejected / fraud blocked — `message` is the backend's `errors[0].reason.result` with a generic fallback, never nil), `.authenticationError` (session token rejected, HTTP 401 / 403), `.userCancelled` (user dismissed the 3DS sheet), `.unknownError` (network or SDK error — `rawError` carries the underlying error). The `onSessionExpired` closure (supplied at `createSession` time) fires ONLY on paths that leave the Payrails execution non-terminal (pending) on the backend — i.e. the user abandoned 3DS and the confirmation poll couldn't surface a backend terminal during the grace window. Backend-confirmed terminals (success, authorization-failed, cancel-URL) do NOT trigger it, because those executions are closed cleanly. See [`error-handling.md`](error-handling.md) for the full mapping.
 
 ## 3DS flow (detailed)
 

--- a/docs/internal/error-handling.md
+++ b/docs/internal/error-handling.md
@@ -63,26 +63,30 @@ public enum PayrailsError: Error, LocalizedError {
 │                                    ▼                            │
 │                          session.handle(error:)                 │
 │                                    │                            │
-│                    ┌───────────────┼───────────────┐            │
-│                    ▼               ▼               ▼            │
-│            .authenticationError  PayrailsError   raw Error      │
-│                    │               │               │            │
-│                    ▼               ▼               ▼            │
-│           .authorizationFailed  .error(e)   .error(.unknown)   │
+│                                    ▼                            │
+│                         AuthorizationFailure                    │
+│                          { code, message, rawError }            │
 │                                                                 │
 │                           OnPayResult                           │
 │                              │                                  │
 │                              ▼                                  │
 │                 CardPaymentButton.handlePaymentResult           │
 │                              │                                  │
-│              ┌───────────────┼───────────────┐                  │
-│              ▼               ▼               ▼                  │
-│         .success    .authorizationFailed  .failure/.error       │
-│              │          .cancelledByUser      │                 │
-│              ▼               ▼               ▼                  │
-│       onAuthorizeSuccess  onAuthorizeFailed  onAuthorizeFailed  │
-│                          (logged only for                       │
-│                           cancelledByUser)                      │
+│       ┌──────────────────────┼──────────────────────┐           │
+│       ▼                      ▼                      ▼           │
+│   .success         .authorizationFailed         .pending        │
+│       │                  (failure)                  │           │
+│       ▼                      ▼                      ▼           │
+│  onAuthorize-       onAuthorizeFailed         onAuthorize-      │
+│  Success             (failure:)               Pending           │
+│                                                                 │
+│ The `onSessionExpired` closure (supplied at `createSession`)    │
+│ fires in parallel on any path that leaves the Payrails          │
+│ execution non-terminal (pending) on the backend — typically     │
+│ when the user dismissed 3DS and the confirmation-poll grace     │
+│ window found no backend terminal. Backend-confirmed terminals   │
+│ (success / authorization-failed / cancelled-via-URL) do NOT     │
+│ trigger it — those executions are closed cleanly.               │
 └─────────────────────────────────────────────────────────────────┘
 ```
 
@@ -95,51 +99,52 @@ public enum PayrailsError: Error, LocalizedError {
 ```
 CardPaymentButton.pay()
   └── session.executePayment(with:saveInstrument:presenter:onResult:)
-        ├── prepareHandler() fails → onResult(.error(.unsupportedPayment or .incorrectPaymentSetup))
-        ├── invalid amount format  → onResult(.error(.invalidDataFormat))
+        ├── prepareHandler() fails → onResult(.authorizationFailed(.unknownError(.unsupportedPayment | .incorrectPaymentSetup)))
+        ├── invalid amount format  → onResult(.authorizationFailed(.unknownError(.invalidDataFormat)))
         └── paymentHandler.makePayment()
               └── PayrailsAPI calls
-                    ├── HTTP 401           → handle(error:) → onResult(.authorizationFailed)
-                    ├── PayrailsError      → handle(error:) → onResult(.error(payrailsError))
-                    └── any other Error    → handle(error:) → onResult(.error(.unknown(error:)))
+                    ├── HTTP 401/403       → handle(error:) → onResult(.authorizationFailed(.authenticationError))
+                    │                                       → refreshIfPossible()
+                    ├── backend decline    → onResult(.authorizationFailed(.authorizationError(message: <backend>)))
+                    ├── PayrailsError      → handle(error:) → onResult(.authorizationFailed(.unknownError(payrailsError)))
+                    │                                       → refreshIfPossible() for polling timeout
+                    └── any other Error    → handle(error:) → onResult(.authorizationFailed(.unknownError(error)))
 
 ```
 
 ### Delegate translation
 
-`session.handle(error:)` is the central error-to-delegate translator:
+The session funnels every failure path into `OnPayResult.authorizationFailed(AuthorizationFailure)`, where the carried struct has `.code` (discriminator), `.message` (backend detail or generic fallback), and `.rawError` (underlying error when one exists). Construction goes through static helpers on `AuthorizationFailure`:
 
 ```swift
-private func handle(error: Error) {
-    if let payrailsError = error as? PayrailsError {
-        switch payrailsError {
-        case .authenticationError:
-            onResult?(.authorizationFailed)   // special case: auth errors → authorizationFailed
-        default:
-            onResult?(.error(payrailsError))
-        }
-    } else {
-        onResult?(.error(PayrailsError.unknown(error: error)))
-    }
-    isPaymentInProgress = false
-    onResult = nil
-    paymentHandler = nil
+extension AuthorizationFailure {
+    static func authorizationError(message: String) -> AuthorizationFailure  // backend decline
+    static var authenticationError: AuthorizationFailure                     // 401 / 403
+    static var userCancelled: AuthorizationFailure                           // user abandoned flow
+    static func unknownError(_ error: PayrailsError?) -> AuthorizationFailure
 }
 ```
 
-This means `.authenticationError` is silently converted to `.authorizationFailed` at the `OnPayResult` level. Merchants see a clean "authorization failed" state rather than needing to match a specific error case.
-
 ### CardPaymentButton translation
 
-`CardPaymentButton.handlePaymentResult(_:)` maps `OnPayResult` to delegate calls:
+`CardPaymentButton.handlePaymentResult(_:)` maps `OnPayResult` cases to delegate calls:
 
 ```swift
-case .success         → delegate.onAuthorizeSuccess
-case .authorizationFailed, .failure, .error → delegate.onAuthorizeFailed
-case .cancelledByUser → logged only (no delegate call)
+case .success                       → delegate.onAuthorizeSuccess(self)
+case .authorizationFailed(failure)  → delegate.onAuthorizeFailed(self, failure: failure)
+case .pending                       → delegate.onAuthorizePending(self)
+
+// `failure.message` for `.authorizationError` carries the backend's
+// `errors[0].reason.result`, extracted in PayrailsAPI.checkExecutionStatus →
+// Status.paymentStatus(with:). When the backend provides no detail it falls back
+// to PayrailsAPI.genericAuthorizationFailedMessage ("Authorization failed") —
+// never nil. Mirrors web-sdk's
+// `confirmResult.finalState?.errors?.[0]?.reason?.result || 'Authorization Failed'`.
 ```
 
-Note: `.failure` and `.error` both call `onAuthorizeFailed`. Merchants cannot distinguish these two at the delegate level. If you need to surface more granularity, you must change the delegate protocol and update the audit doc.
+The `onSessionExpired` closure (supplied to `Payrails.createSession(with:onSessionExpired:)`) is invoked by the session — NOT the button — on any path that leaves the Payrails execution non-terminal on the backend. This is single-fire-per-poisoned-execution and decoupled from per-button delegate dispatch; merchants never wire it on a button.
+
+`AuthorizationFailureReason` mirrors the Web SDK's `AuthorizationFailureReasons` enum 1:1 (raw values match). The same mapping is mirrored in `CardPaymentForm`, `StoredInstrumentPaymentButton`, and `GenericRedirectButton`.
 
 ---
 

--- a/docs/internal/merchant-usage-guide.md
+++ b/docs/internal/merchant-usage-guide.md
@@ -185,9 +185,18 @@ extension CheckoutViewController: PayrailsCardPaymentButtonDelegate, PaymentPres
         }
     }
 
-    func onAuthorizeFailed(_ button: Payrails.CardPaymentButton) {
+    func onAuthorizeFailed(_ button: Payrails.CardPaymentButton, failure: AuthorizationFailure) {
         activityIndicator.stopAnimating()
-        showError("Payment was not completed. Please try again.")
+        switch failure.code {
+        case .userCancelled:
+            showInfo("Payment cancelled.")
+        case .authorizationError:
+            showError("Declined: \(failure.message)")
+        case .authenticationError:
+            showError("Session expired. Please retry.")
+        case .unknownError:
+            showError("Payment failed: \(failure.rawError?.localizedDescription ?? failure.message).")
+        }
     }
 
     func onThreeDSecureChallenge(_ button: Payrails.CardPaymentButton) {
@@ -195,6 +204,8 @@ extension CheckoutViewController: PayrailsCardPaymentButtonDelegate, PaymentPres
     }
 }
 ```
+
+> Session refresh is handled by the `onSessionExpired` closure supplied to `Payrails.createSession(with:onSessionExpired:)`, NOT by a per-button delegate method. The SDK invokes the closure when it detects the execution is no longer reusable and swaps its internal config in place — the merchant's `Session` reference and cached buttons keep working unchanged.
 
 ---
 
@@ -215,7 +226,8 @@ User taps "Pay"
 SDK authorizes with stored instrument
         │
         ├──── Success ──► onAuthorizeSuccess
-        └──── Failure ──► onAuthorizeFailed
+        └──── Failure ──► onAuthorizeFailed(_:failure:)
+                          (+ onSessionExpired closure if execution left pending)
 ```
 
 If the user deselects the instrument, the button returns to card form mode.

--- a/docs/internal/public-api-audit.md
+++ b/docs/internal/public-api-audit.md
@@ -106,7 +106,10 @@ Living document tracking every public symbol in the SDK. Update this whenever a 
 |---|---|---|
 | `OnInitCallback` | PUBLIC | typealias |
 | `OnPayCallback` | PUBLIC | typealias |
-| `OnPayResult` | PUBLIC | `.success`, `.authorizationFailed`, `.failure`, `.error`, `.cancelledByUser` |
+| `OnPayResult` | PUBLIC | `.success`, `.authorizationFailed(AuthorizationFailure)`, `.pending`. ONB-739 collapsed the prior 5-case enum into a 3-case shape; failure detail moved onto the carried `AuthorizationFailure` struct. `.pending` surfaces when the backend returns `pending` with `actionRequired: nil` (no 3DS, no redirect). |
+| `AuthorizationFailure` | PUBLIC | Struct passed to `onAuthorizeFailed(_:failure:)`. Fields: `code: AuthorizationFailureReason`, `message: String` (backend detail or generic fallback, never nil), `rawError: Error?`. Flat shape, mirrors Web SDK's `onFailed` payload. Added in ONB-739. |
+| `AuthorizationFailureReason` | PUBLIC | String-raw-valued discriminator on `AuthorizationFailure.code`. Cases: `.authorizationError` ("AUTHORIZATION_ERROR"), `.authenticationError` ("AUTHENTICATION_ERROR"), `.userCancelled` ("USER_CANCELLED"), `.unknownError` ("UNKNOWN_ERROR"). Raw values match Web's `AuthorizationFailureReasons` 1:1. Added in ONB-739. |
+| `SessionExpiredHandler` | PUBLIC | typealias for `(@escaping (Result<Payrails.InitData, Error>) -> Void) -> Void`. Closure supplied at `Payrails.createSession(with:onSessionExpired:)` time; the SDK invokes it when it detects the current execution is no longer reusable so the merchant's backend can mint a fresh `InitData`. Added in ONB-739. |
 
 ---
 
@@ -122,8 +125,9 @@ Living document tracking every public symbol in the SDK. Update this whenever a 
 | `Payrails.CardPaymentButton.setStoredInstrument(_:)` | PUBLIC | Switch to stored instrument mode |
 | `Payrails.CardPaymentButton.clearStoredInstrument()` | PUBLIC | Revert to card form mode |
 | `Payrails.CardPaymentButton.getStoredInstrument()` | PUBLIC | Read current stored instrument |
-| `PayrailsCardPaymentButtonDelegate` | PUBLIC | |
+| `PayrailsCardPaymentButtonDelegate` | PUBLIC | ONB-739: `onAuthorizeFailed` signature changed to `(_:failure:)` taking an `AuthorizationFailure` struct (breaking). Per-button `onSessionExpired(_:)` was removed in favour of the closure on `createSession`. |
 | `PayrailsCardFormDelegate` | PUBLIC | |
+| `PayrailsCardPaymentFormDelegate` | PUBLIC | ONB-739: same `(_:failure:)` change; per-button `onSessionExpired(_:)` removed. |
 
 ---
 
@@ -191,7 +195,7 @@ Living document tracking every public symbol in the SDK. Update this whenever a 
 | Symbol | Status | Notes |
 |---|---|---|
 | `Payrails.GenericRedirectButton` | PUBLIC | |
-| `GenericRedirectPaymentButtonDelegate` | PUBLIC | |
+| `GenericRedirectPaymentButtonDelegate` | PUBLIC | ONB-739: `onAuthorizeFailed` signature changed to `(_:failure:)` taking an `AuthorizationFailure` struct (breaking). Per-button `onSessionExpired(_:)` was removed in favour of the closure on `createSession`. Legacy `onPaymentSessionExpired(_:)` retained. |
 
 ---
 
@@ -208,7 +212,7 @@ Living document tracking every public symbol in the SDK. Update this whenever a 
 | `Payrails.StoredInstrumentView` | PUBLIC | |
 | `PayrailsStoredInstrumentsDelegate` | PUBLIC | |
 | `PayrailsStoredInstrumentViewDelegate` | PUBLIC | |
-| `PayrailsStoredInstrumentPaymentButtonDelegate` | PUBLIC | |
+| `PayrailsStoredInstrumentPaymentButtonDelegate` | PUBLIC | Deprecated. ONB-739: `onAuthorizeFailed` signature changed to `(_:failure:)` taking an `AuthorizationFailure` struct (breaking). Per-button `onSessionExpired(_:)` was removed in favour of the closure on `createSession`. |
 | `StoredInstrumentsStyle` | PUBLIC | |
 | `StoredInstrumentButtonStyle` | PUBLIC | |
 | `StoredInstrumentsTranslations` | PUBLIC | |

--- a/docs/public/concepts.md
+++ b/docs/public/concepts.md
@@ -71,7 +71,16 @@ Assign the delegate before adding the element to the window.
 │                   ──► user completes challenge in SFSafariViewController
 │                   ──► SDK polls for final status
 └─ no 3DS  ──► result delivered immediately
-7. delegate.onAuthorizeSuccess / onAuthorizeFailed called
+7. delegate callback fires:
+   - success  → delegate.onAuthorizeSuccess(_:)
+   - failure  → delegate.onAuthorizeFailed(_:failure:)
+                (failure.code discriminates: .userCancelled / .authorizationError /
+                 .authenticationError / .unknownError)
+   - pending  → delegate.onAuthorizePending(_:)
+   In parallel, if the execution is left in `authorizePending` (e.g. the user
+   abandoned 3DS), the SDK fires the `onSessionExpired` closure supplied at
+   `createSession` time to swap the internal config in place — the merchant's
+   `Session` reference and cached buttons keep working.
 ```
 
 ### Stored instrument payment

--- a/docs/public/quick-start.md
+++ b/docs/public/quick-start.md
@@ -85,12 +85,24 @@ let configuration = Payrails.Configuration(
 )
 
 do {
-    let session = try await Payrails.createSession(with: configuration)
+    let session = try await Payrails.createSession(
+        with: configuration,
+        onSessionExpired: { completion in
+            // Re-run your backend's init flow (authentication + initSdk) and hand
+            // the fresh InitData back. The SDK swaps its internal config in place —
+            // your `session` reference and any cached buttons / forms keep working.
+            fetchFreshPayrailsInitData { result in
+                completion(result)
+            }
+        }
+    )
     // session is ready; store it or proceed to build your UI
 } catch {
     print("SDK initialization failed:", error.localizedDescription)
 }
 ```
+
+> **Recommended:** always supply `onSessionExpired` at `createSession` time. The SDK invokes it when it detects the current execution is no longer reusable (most commonly: the user abandoned a 3DS challenge). Without it, the next payment attempt against the poisoned `Session` fails naturally and the SDK logs a warning at init.
 
 ### Callback
 
@@ -175,8 +187,28 @@ extension CheckoutViewController: PayrailsCardPaymentButtonDelegate {
         // Payment succeeded — navigate to confirmation screen
     }
 
-    func onAuthorizeFailed(_ button: Payrails.CardPaymentButton) {
-        // Payment failed or was declined — show error to user
+    func onAuthorizeFailed(_ button: Payrails.CardPaymentButton, failure: AuthorizationFailure) {
+        switch failure.code {
+        case .userCancelled:
+            // User dismissed the 3DS sheet or otherwise abandoned the flow.
+            // The SDK has already triggered the `onSessionExpired` refresh closure
+            // (supplied at `createSession`) so retries continue to work against
+            // the same `Session` reference.
+            statusLabel.text = "Payment cancelled."
+        case .authorizationError:
+            // Issuer declined / 3DS rejected. `failure.message` is the backend's
+            // extracted failure reason (e.g. "Insufficient funds") with a generic
+            // fallback — never nil.
+            statusLabel.text = "Declined: \(failure.message)"
+        case .authenticationError:
+            // Session token rejected (401 / 403). The SDK fires `onSessionExpired`
+            // in the background; ask the user to retry.
+            statusLabel.text = "Session expired. Please retry."
+        case .unknownError:
+            // Network, SDK, or other unexpected error. `failure.rawError` carries
+            // the underlying error when one exists.
+            statusLabel.text = "Payment failed: \(failure.rawError?.localizedDescription ?? failure.message)."
+        }
     }
 
     func onThreeDSecureChallenge(_ button: Payrails.CardPaymentButton) {

--- a/docs/public/sdk-api-reference.md
+++ b/docs/public/sdk-api-reference.md
@@ -65,24 +65,45 @@ public struct Payrails.Configuration {
 }
 ```
 
-### `Payrails.createSession(with:)`
+### `Payrails.createSession(with:onSessionExpired:)`
 
 Creates and stores a session. All factory methods use the most recently created session.
 
 ```swift
 // Async/await
 public static func createSession(
-    with configuration: Payrails.Configuration
+    with configuration: Payrails.Configuration,
+    onSessionExpired: SessionExpiredHandler? = nil
 ) async throws -> Payrails.Session
 
 // Callback
 public static func createSession(
     with configuration: Payrails.Configuration,
+    onSessionExpired: SessionExpiredHandler? = nil,
     onInit: OnInitCallback
 )
 
 public typealias OnInitCallback = (Result<Payrails.Session, PayrailsError>) -> Void
+
+public typealias SessionExpiredHandler = (
+    @escaping (Result<Payrails.InitData, Error>) -> Void
+) -> Void
 ```
+
+The `onSessionExpired` closure lets the SDK self-heal when the underlying Payrails execution becomes unreusable (typically: user abandoned a 3DS challenge and the backend execution stayed in `authorizePending`). The merchant supplies a closure that fetches fresh `InitData` from their backend; the SDK swaps its internal config in place — the merchant's `Session` reference and cached buttons / forms keep working unchanged.
+
+```swift
+let session = try await Payrails.createSession(
+    with: Payrails.Configuration(initData: initData, option: .init(env: .production)),
+    onSessionExpired: { completion in
+        myBackend.fetchPayrailsInit { result in
+            completion(result)   // .success(Payrails.InitData) or .failure(Error)
+        }
+    }
+)
+```
+
+If the closure is omitted, the SDK logs a warning at init time and cannot recover from a poisoned execution — the next payment attempt against that `Session` will fail naturally.
 
 ---
 
@@ -341,18 +362,51 @@ See [How to Update Checkout Amount](how-to-update-checkout-amount.md) for the fu
 
 ## Callbacks and results
 
-```swift
-public typealias OnInitCallback = (Result<Payrails.Session, PayrailsError>) -> Void
-public typealias OnPayCallback = (OnPayResult) -> Void
+Payment outcomes are delivered to your `CardPaymentButton` / `CardPaymentForm` / `StoredInstrumentPaymentButton` / `GenericRedirectButton` delegate. Failures arrive as an `AuthorizationFailure` struct — a flat `{ code, message, rawError }` shape that mirrors the Web SDK's `onFailed` payload:
 
-public enum OnPayResult {
-    case success
-    case authorizationFailed
-    case failure
-    case error(PayrailsError)
-    case cancelledByUser
+```swift
+/// Payload passed to `onAuthorizeFailed(_:failure:)` on every delegate protocol.
+public struct AuthorizationFailure {
+    /// Discriminating code — switch on this to give each outcome the right UX.
+    public let code: AuthorizationFailureReason
+    /// Human-readable detail. Backend's `errors[0].reason.result` for `.authorizationError`,
+    /// generic fallback for the other cases. Never nil.
+    public let message: String
+    /// Underlying error when one exists (typically populated for `.unknownError`).
+    public let rawError: Error?
+}
+
+/// String-raw-valued discriminator. Raw values match the Web SDK's
+/// `AuthorizationFailureReasons` 1:1.
+public enum AuthorizationFailureReason: String {
+    /// Authorization rejected — issuer declined, 3DS rejected, fraud blocked, etc.
+    case authorizationError  = "AUTHORIZATION_ERROR"
+    /// Session token was rejected (HTTP 401 / 403). The merchant must
+    /// re-initialise the session; the SDK also fires its `onSessionExpired`
+    /// refresh in the background.
+    case authenticationError = "AUTHENTICATION_ERROR"
+    /// The user intentionally abandoned the flow (e.g. swiped the 3DS sheet away).
+    case userCancelled       = "USER_CANCELLED"
+    /// Network failure, decode error, encryption failure, polling timeout, or
+    /// any other unexpected error. `rawError` carries the underlying error.
+    case unknownError        = "UNKNOWN_ERROR"
 }
 ```
+
+> Web's `VALIDATION_FAILED` is intentionally absent on iOS — input validation runs client-side before submission and never reaches this path.
+
+### Delegate callbacks fired
+
+| Outcome | Delegate method fired |
+|---|---|
+| Authorization succeeded | `onAuthorizeSuccess(self)` |
+| Backend declined / rejected authorization | `onAuthorizeFailed(self, failure: .authorizationError(message:))` |
+| Session token expired / rejected | `onAuthorizeFailed(self, failure: .authenticationError)` |
+| User dismissed 3DS sheet (no backend terminal confirmed) | `onAuthorizeFailed(self, failure: .userCancelled)` |
+| Network / SDK error | `onAuthorizeFailed(self, failure: .unknownError(_))` |
+| Backend execution pending with no action required | `onAuthorizePending(self)` |
+
+When the user dismisses the 3DS sheet (or any other path that leaves the Payrails execution in `authorizePending`), the SDK additionally invokes the merchant's `onSessionExpired` closure (supplied at `createSession`) in the background to rebuild its internal config in place — the merchant's `Session` reference keeps working. If the closure was not supplied, the SDK logs a warning at `createSession` time and the next payment attempt against the `Session` will fail naturally against the dead execution.
 
 ---
 
@@ -387,12 +441,27 @@ extension MyCheckoutViewController: PaymentPresenter {
 public protocol PayrailsCardPaymentButtonDelegate: AnyObject {
     func onPaymentButtonClicked(_ button: Payrails.CardPaymentButton)
     func onAuthorizeSuccess(_ button: Payrails.CardPaymentButton)
+    func onAuthorizePending(_ button: Payrails.CardPaymentButton)
     func onThreeDSecureChallenge(_ button: Payrails.CardPaymentButton)
-    func onAuthorizeFailed(_ button: Payrails.CardPaymentButton)
-    // Optional — default implementation provided
+
+    /// Fires for every terminal failure of an authorization attempt. The `failure`
+    /// payload's `.code` discriminates between issuer decline, authentication
+    /// failure, user cancellation, and other errors — see `AuthorizationFailure`.
+    func onAuthorizeFailed(_ button: Payrails.CardPaymentButton, failure: AuthorizationFailure)
+
+    /// Optional — default no-op.
     func onStoredInstrumentChanged(_ button: Payrails.CardPaymentButton, instrument: StoredInstrument?)
 }
 ```
+
+> **Breaking change in ONB-739.** The pre-ONB-739 signature was
+> `onAuthorizeFailed(_ button: Payrails.CardPaymentButton)` with no payload.
+> Merchants migrating from earlier versions must update their delegate
+> conformance to take `failure: AuthorizationFailure` and (if they relied on
+> session-expiry signaling) supply the `onSessionExpired` closure to
+> `createSession`. See the
+> [card-payment-flow documentation](../card-payment-flow-documentation.md)
+> for a migration example.
 
 ### `PayrailsCardFormDelegate`
 

--- a/docs/public/troubleshooting.md
+++ b/docs/public/troubleshooting.md
@@ -111,19 +111,25 @@ The SDK writes to `LogStore.shared` and also calls `Swift.print`. To see logs in
 - The PayPal SDK requires a client ID in the init payload config; verify the payload includes it
 
 **PayPal checkout WebView dismissed with no result**
-- The user cancelled — `OnPayResult.cancelledByUser` is delivered via the delegate callback
+- The user cancelled — `onAuthorizeFailed(_:failure:)` fires with `failure.code == .userCancelled`. In parallel, the SDK invokes the `onSessionExpired` closure supplied at `createSession` time to refresh the underlying execution; the merchant's cached `Session` reference keeps working.
 
 ---
 
 ## Payment issues
 
-**Payment results in `.authorizationFailed`**
-- This maps to `PayrailsError.authenticationError` — the session token has expired
-- Re-initialize the session with a fresh init payload from your backend
+**Payment failed — how do I know why?**
+- `onAuthorizeFailed(_ button:, failure:)` carries an `AuthorizationFailure` struct. Switch on `failure.code` to give each case the right UX, and read `failure.message` / `failure.rawError` for detail:
+  - `.userCancelled` — user dismissed the 3DS sheet. Show neutral copy, no error banner.
+  - `.authorizationError` — authorization rejected (issuer decline, 3DS rejected, fraud blocked, etc.). `failure.message` is the backend's `errors[0].reason.result`, falling back to "Authorization failed" when no detail is provided.
+  - `.authenticationError` — session token rejected (HTTP 401 / 403). The SDK also fires its `onSessionExpired` refresh in the background.
+  - `.unknownError` — network, SDK, or other unexpected failure. Inspect `failure.rawError` for the underlying error.
 
-**Payment results in `.failure` after 3DS**
-- The card issuer declined the transaction post-3DS; this is not an SDK error
-- Show the user an appropriate message and optionally offer another payment method
+**My retry on the same card doesn't work after a failure**
+- Payrails executions are single-use. Once a payment terminates (success or failure), the same execution cannot be retried. Supply the `onSessionExpired` closure to `Payrails.createSession(with:onSessionExpired:)` so the SDK can mint a fresh execution in-place when needed; the merchant's `Session` reference and cached buttons keep working unchanged.
+
+**3DS challenge never appears / `presentPayment(_:)` not called**
+- Confirm that `payButton.presenter = self` is set on the `CardPaymentButton`
+- Confirm your view controller conforms to both `PaymentPresenter` and `PayrailsCardPaymentFormDelegate` if needed
 
 **3DS challenge never appears / `presentPayment(_:)` not called**
 - Confirm that `payButton.presenter = self` is set on the `CardPaymentButton`

--- a/docs/stored-instrument-payment-flow-documentation.md
+++ b/docs/stored-instrument-payment-flow-documentation.md
@@ -198,15 +198,18 @@ func pay(with type: PaymentType? = nil, storedInstrument: StoredInstrument? = ni
 func getStoredInstrument() -> StoredInstrument? // Returns stored instrument if in stored mode
 ```
 
-**Unified Delegate Protocol**:
+**Unified Delegate Protocol** (as of ONB-739):
 ```swift
 protocol PayrailsCardPaymentButtonDelegate: AnyObject {
     func onPaymentButtonClicked(_ button: CardPaymentButton)
     func onAuthorizeSuccess(_ button: CardPaymentButton)
+    func onAuthorizePending(_ button: CardPaymentButton)
     func onThreeDSecureChallenge(_ button: CardPaymentButton) // Only for card form mode
-    func onAuthorizeFailed(_ button: CardPaymentButton)
+    func onAuthorizeFailed(_ button: CardPaymentButton, failure: AuthorizationFailure)
 }
 ```
+
+> Session refresh after a poisoned execution is driven by the `onSessionExpired` closure passed to `Payrails.createSession(with:onSessionExpired:)` — NOT a per-button delegate method.
 
 **Factory Methods**:
 ```swift
@@ -400,12 +403,14 @@ let result = await payrails.executePayment(
 switch result {
 case .success:
     print("Payment successful")
-case .failure, .authorizationFailed:
-    print("Payment failed")
-case .error(let error):
-    print("Payment error: \(error)")
-case .cancelledByUser:
-    print("Payment cancelled")
+case .authorizationFailed(.userCancelled):
+    print("Payment cancelled by user")
+case .authorizationFailed(.authorizationError(let message)):
+    print("Payment declined: \(message)")
+case .authorizationFailed(.unknownError(let error)):
+    print("Payment error: \(String(describing: error))")
+case .pending:
+    print("Execution pending — refresh the session before retrying")
 }
 ```
 
@@ -637,22 +642,31 @@ let newButton = Payrails.createCardPaymentButton(
 
 #### 2. Update Delegate Conformance
 ```swift
-// Old delegate (deprecated)
+// Old delegate (deprecated; signatures updated to match ONB-739)
 extension ViewController: PayrailsStoredInstrumentPaymentButtonDelegate {
     func onPaymentButtonClicked(_ button: StoredInstrumentPaymentButton) { }
     func onAuthorizeSuccess(_ button: StoredInstrumentPaymentButton) { }
-    func onAuthorizeFailed(_ button: StoredInstrumentPaymentButton) { }
+    func onAuthorizeFailed(_ button: StoredInstrumentPaymentButton, failure: AuthorizationFailure) { }
 }
 
-// New unified delegate
+// New unified delegate (ONB-739 shape)
 extension ViewController: PayrailsCardPaymentButtonDelegate {
     func onPaymentButtonClicked(_ button: CardPaymentButton) { }
     func onAuthorizeSuccess(_ button: CardPaymentButton) { }
-    func onThreeDSecureChallenge(_ button: CardPaymentButton) { 
+    func onAuthorizePending(_ button: CardPaymentButton) { }
+    func onThreeDSecureChallenge(_ button: CardPaymentButton) {
         // Not applicable for stored instruments, but required by protocol
     }
-    func onAuthorizeFailed(_ button: CardPaymentButton) { }
+    func onAuthorizeFailed(_ button: CardPaymentButton, failure: AuthorizationFailure) {
+        // `failure.code` discriminates: .userCancelled / .authorizationError /
+        //                               .authenticationError / .unknownError
+        // `failure.message` carries backend detail; `failure.rawError` carries the
+        // underlying error when one exists.
+    }
 }
+
+// Session refresh after a poisoned execution is configured at session creation:
+//   Payrails.createSession(with: configuration, onSessionExpired: { completion in ... })
 ```
 
 #### 3. Update StoredInstrumentView Integration


### PR DESCRIPTION
## Description

Fixes two merchant-reported issues in the iOS 3DS challenge flow that left the app stuck in "Processing payment…", and reshapes the failure-callback surface to match the Web SDK while we still have the window for a breaking change.

**Issue 1 — Hanging flows.** When the 3DS WebView's backend redirect chain stalled on `/redirect/wait/workflow/…` (or any URL the SDK didn't recognize as terminal), no callback fired and the app sat in "Processing payment…" indefinitely.

**Issue 2 — Dismissable popup.** When the user proactively swiped the 3DS sheet away mid-flow, the SDK fired no callback at all. Same indefinite hang.

## How it's fixed

### 1. Concurrent backend polling — solves Issue 1

A background poll task runs in parallel with the WebView, querying the execution URL for an actual terminal status (`authorizeSuccessful` / `authorizeFailed`). A single-shot `claimTerminal()` NSLock arbitrates: whichever signal (WebView URL match or backend terminal) arrives first reports the outcome; the loser is a silent no-op. The SDK is no longer blind during the 3DS phase.

### 2. User-dismiss detection — solves Issue 2

`PayWebViewController` conforms to `UIAdaptivePresentationControllerDelegate` and forwards `presentationControllerDidDismiss(_:)` to the session. After a 3s grace window (for the background poll to surface a real terminal first), the session emits `OnPayResult.cancelledByUser`.

### 3. Failure-callback redesign — Web parity, breaking change

The PR initially shipped a new `onPaymentCancelled` delegate method (source-compatible). After team review the design pivoted to match Web 1:1 — a single `onAuthorizeFailed(_:reason:)` with a discriminating enum, plus a new `onSessionExpired(_:)` callback signaling the Payrails execution can no longer be reused. Justified because Blacklane is the only iOS merchant and has not gone live yet.

## ⚠️ Breaking changes for merchants

Both changes affect any merchant whose code conforms to one of the SDK's four delegate protocols:

- `PayrailsCardPaymentButtonDelegate`
- `PayrailsCardPaymentFormDelegate`
- `PayrailsStoredInstrumentPaymentButtonDelegate` (deprecated, kept consistent)
- `GenericRedirectPaymentButtonDelegate`

### Change 1 — `onAuthorizeFailed` signature

```diff
- func onAuthorizeFailed(_ button: Payrails.CardPaymentButton)
+ func onAuthorizeFailed(_ button: Payrails.CardPaymentButton, reason: AuthorizeFailureReason)
```

The new `AuthorizeFailureReason` enum (defined in `Payrails/Classes/Public/Domains/Callbacks.swift`) mirrors Web's `AuthorizationFailureReasons` 1:1:

```swift
public enum AuthorizeFailureReason {
    case validationFailed
    case authorizationError(PayrailsError?)
    case authenticationError(PayrailsError?)
    case userCancelled
    case unknownError(PayrailsError?)
}
```

### Change 2 — New `onSessionExpired` callback

```swift
func onSessionExpired(_ button: Payrails.CardPaymentButton)
```

Fires immediately after every terminal `onAuthorizeFailed`. The Payrails execution is single-use; once it terminates, the merchant must produce a fresh `Session` (via a new backend execution) before any subsequent attempt.

Default implementation is a no-op, so merchants who don't override it still compile — but they'll hit backend 4xx errors on retry until they implement it.

### Migration cheat-sheet for Blacklane

Old:
```swift
func onAuthorizeFailed(_ button: Payrails.CardPaymentButton) {
    statusLabel.text = "Payment failed."
}
```

New:
```swift
func onAuthorizeFailed(_ button: Payrails.CardPaymentButton, reason: AuthorizeFailureReason) {
    switch reason {
    case .userCancelled:
        statusLabel.text = "Payment cancelled."           // neutral UX
    case .authorizationError:
        statusLabel.text = "Your card was declined."
    case .authenticationError:
        statusLabel.text = "3DS authentication failed."
    case .validationFailed:
        statusLabel.text = "Please check your card details."
    case let .unknownError(error):
        statusLabel.text = "Payment failed: \(error?.localizedDescription ?? "unknown")."
    }
}

func onSessionExpired(_ button: Payrails.CardPaymentButton) {
    // Payrails execution is dead; refresh before any retry.
    refreshSessionFromBackend()
}
```

The companion `bootstrap-ios` PR shows the full migration.

## Considered alternatives (for posterity)

- **Option A — Merge cancel into `onAuthorizeFailed` with no discriminator.** Source-compatible but conflates "user changed their mind" with "card declined" → bad UX. Rejected.
- **Option B — Add a separate `onPaymentCancelled` delegate method.** Source-compatible; merchants opt in to handle cancel distinctly. Shipped initially in commits `a4b27bc` + `d49a46b`, then reverted after team feedback that it diverges from Web's discriminator pattern.
- **Option C (shipped) — `onAuthorizeFailed(_:reason:)` + `onSessionExpired(_:)`.** Web parity. Breaking but acceptable since Blacklane hasn't shipped.

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [x] 🧑‍💻 Code Refactor (breaking API redesign)
- [ ] 🔥 Performance Improvements
- [x] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Release
- [ ] ⏩ Revert

## Screenshots/Recordings

No visual SDK changes. Verified on iPhone 16e simulator against staging tenant with Checkout.com card `4275 7655 7431 9271`:

- **Issue 1 repro** — 3DS WebView stalls on `/redirect/wait/workflow/…`. Background poll observes `authorizeFailed` at +8s, dismisses the WebView, fires `onAuthorizeFailed(reason: .authorizationError(_))` followed by `onSessionExpired`. Merchant sees "Your card was declined."
- **Issue 2 repro** — swipe the 3DS sheet down. After the 3s grace window `onAuthorizeFailed(reason: .userCancelled)` fires followed by `onSessionExpired`. Merchant sees a neutral "Payment cancelled." (gray banner, distinct from the red "declined" banner).
- **Regression** — successful 3DS flow unchanged; non-stalled failure flow unchanged.

## Added tests?

- [x] 👍 yes

Full suite: **141 tests, 0 failures** (was 129 before this PR). New tests cover:

- `AuthorizeFailureReason` propagation through `onAuthorizeFailed(_:reason:)` for `.userCancelled`, `.authorizationError`, `.unknownError(payload)` (verifying the `PayrailsError` payload survives)
- `onSessionExpired` override receives the call + default no-op for minimal delegates
- Compile-time conformance tests for the redesigned protocol surface on all four delegate protocols
- `PayWebViewController.presentationControllerDidDismiss(_:)` invokes the user-dismiss callback (load-bearing for the Issue-2 fix)
- Internal protocol defaults (`PaymentHandler.dismissPresentedView`, `PaymentHandlerDelegate.paymentHandlerUserDidDismissChallenge`)

`MockCardPaymentButtonDelegate` extended to record the new `AuthorizeFailureReason` and `onSessionExpired` signals.

**Follow-up flagged**: end-to-end orchestration tests (`claimTerminal()` race arbitration, 3s grace-window timing) need `URLProtocol`-based mocking of `URLSession.shared`, which the test target doesn't have today. A separate PR should introduce a `MockURLProtocol` helper. A `// MARK:` comment in `PayrailsTests.swift` calls this out.

## Added to documentation?

- [x] 🙅 no documentation needed

The new `AuthorizeFailureReason` enum and `onSessionExpired` delegate method are documented inline in their declarations. A docs.payrails.com update should follow this PR.

## Post-release tasks

- **Bootstrap demo app** — companion change in `bootstrap-ios` migrates `SavedCardsViewController` and `FullIntegrationDemoViewController` to the new API. Land this PR first.
- **Blacklane coordination** — breaking change; coordinate the SDK release with their integration team so they can update their delegate conformances in the same window.
- **Web SDK alignment** — iOS `AuthorizeFailureReason` values track Web's `AuthorizationFailureReasons` 1:1 today. If Web adds new codes later, mirror them here.
- **Android parity** — Android's `CardPaymentButton` has the same silent-cancel bug we just fixed on iOS (`OnPayResult.cancelledByUser → Payrails.log(...)` with no delegate dispatch). A separate ticket should bring Android to parity.

## Commit history

```
f9fa4ea ONB-739: Update tests for failure-callback redesign
b9e1b5b ONB-739: Redesign failure callbacks — reason: discriminator + onSessionExpired
d49a46b ONB-739: Tests for 3DS concurrent polling and onPaymentCancelled callbacks    ← Option-B (superseded by b9e1b5b)
a4b27bc ONB-739: Detect user-dismissed 3DS modal, surface via onPaymentCancelled       ← Option-B (superseded by b9e1b5b)
c4ed4bd ONB-739: Concurrent backend polling during 3DS challenge
```

Commits `a4b27bc` + `d49a46b` ship the original Option-B design and remain in history for traceability. `b9e1b5b` + `f9fa4ea` supersede them with the team-reviewed Option-C design. **Final HEAD reflects only the Option-C public API.**