### PR TITLE
ONB-822: release v2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0] - 2026-06-02
+
 ### Added
 - `AuthorizationFailure` struct — payload passed to `onAuthorizeFailed(_:failure:)` on every delegate protocol. Carries `code: AuthorizationFailureReason` (discriminator), `message: String` (backend detail or generic fallback — never nil), and `rawError: Error?` (the underlying error when one exists). Flat `{ code, message, rawError }` shape, matching the Web SDK's `onFailed` payload. (ONB-739)
 - `AuthorizationFailureReason` enum — string-raw-valued discriminator on `AuthorizationFailure.code`. Four cases mirror the Web SDK 1:1: `.authorizationError` ("AUTHORIZATION_ERROR"), `.authenticationError` ("AUTHENTICATION_ERROR"), `.userCancelled` ("USER_CANCELLED"), `.unknownError` ("UNKNOWN_ERROR"). Web's `VALIDATION_FAILED` is intentionally absent — input validation runs client-side before submission. (ONB-739)

--- a/Payrails.podspec
+++ b/Payrails.podspec
@@ -9,7 +9,7 @@
 Pod::Spec.new do |spec|
 
   spec.name         = "Payrails"
-  spec.version      = "1.28.0"
+  spec.version      = "2.0.0"
   spec.swift_version = "5.0"
   spec.summary      = "Payrails Checkout SDK for iOS - Seamless Payment Integration"
   spec.description  = "Payrails Checkout ensures seamless payment integration within iOS applications, providing developers with the means to create versatile payment solutions."

--- a/Payrails/Classes/Public/Version.swift
+++ b/Payrails/Classes/Public/Version.swift
@@ -13,4 +13,4 @@ import Foundation
 
 var LangAndVersion = "iOS SDK v\(SDK_VERSION)"
 
-var SDK_VERSION = "1.28.0"
+var SDK_VERSION = "2.0.0"

--- a/docs/internal/releasing.md
+++ b/docs/internal/releasing.md
@@ -17,12 +17,12 @@ Both must be updated to the same value before releasing.
 
 ```ruby
 # Payrails.podspec
-spec.version = "1.28.0"
+spec.version = "2.0.0"
 ```
 
 ```swift
 // Version.swift
-var SDK_VERSION = "1.28.0"
+var SDK_VERSION = "2.0.0"
 ```
 
 ---
@@ -67,7 +67,7 @@ Releases are triggered by creating a **GitHub Release** with a version tag. The 
    - Tests: `scripts/ci/test.sh`
 
 3. **Create a GitHub Release:**
-   - Tag: `v<version>` (e.g. `v1.28.0`) — must match `spec.version` exactly
+   - Tag: `v<version>` (e.g. `v2.0.0`) — must match `spec.version` exactly
    - Target: `main`
    - Title: `v<version>`
    - Body: changelog summary

--- a/docs/public/sdk-api-reference.md
+++ b/docs/public/sdk-api-reference.md
@@ -1,6 +1,6 @@
 # SDK API Reference
 
-**Current version:** 1.28.0
+**Current version:** 2.0.0
 **Minimum deployment target:** iOS 14.0
 **Swift version:** 5.0+
 **Distribution:** CocoaPods (`Payrails/Checkout`) · Swift Package Manager


### PR DESCRIPTION
## Summary

Prepares the **v2.0.0** release of the Payrails iOS SDK.

- Bumps `SDK_VERSION` (Version.swift) and `spec.version` (Payrails.podspec): `1.28.0` → `2.0.0`
- Promotes `CHANGELOG.md` `[Unreleased]` → `[2.0.0] - 2026-06-02`
- Syncs version references in `docs/public/sdk-api-reference.md` and example strings in `docs/internal/releasing.md`

**Major bump** because ONB-739 introduces breaking public API changes (see below).

## Changelog — v2.0.0

### Added
- `AuthorizationFailure` struct (`code`, `message`, `rawError`) — payload on `onAuthorizeFailed(_:failure:)`. (ONB-739)
- `AuthorizationFailureReason` enum discriminator (`.authorizationError`, `.authenticationError`, `.userCancelled`, `.unknownError`). (ONB-739)
- `SessionExpiredHandler` closure + `onSessionExpired:` parameter on `Payrails.createSession(...)`. (ONB-739)
- `OnPayResult.pending` case for backend-pending executions. (ONB-739)
- Concurrent backend polling during 3DS with single-shot `claimTerminal()` arbitration. (ONB-739)
- User-dismiss detection on the 3DS WebView. (ONB-739)

### Changed
- **Breaking:** `onAuthorizeFailed(_:)` → `onAuthorizeFailed(_:failure:)` on all four delegate protocols. (ONB-739)
- **Breaking:** `OnPayResult` collapsed to three cases: `.success`, `.authorizationFailed(AuthorizationFailure)`, `.pending`. (ONB-739)

### Removed
- **Breaking:** `onSessionExpired(_:)` delegate method removed; refresh moved to the `createSession` closure. (ONB-739)

### Fixed
- Apple Pay no longer fails silently after a successful authorization; `didAuthorize` latch gates the spurious cancel. (ONB-766)
- App no longer crashes with "continuation resumed more than once" after Apple Pay. (ONB-767)
- `didAuthorizePayment` emits `.error(nil)` on unparseable `paymentData` instead of hanging. (ONB-766)
- 3DS WebView no longer hangs on stalled redirect chains. (ONB-739)
- 3DS swipe-down dismiss now surfaces `.userCancelled`. (ONB-739)
- Backend `errors[0].reason.result` threaded through to `AuthorizationFailure.message`. (ONB-739)

> ⚠️ **Breaking:** Merchants conforming to any card/redirect delegate protocol must update their `onAuthorizeFailed` signature and remove any `onSessionExpired(_:)` delegate method. See `docs/public/quick-start.md`.

## Validation
- [x] `scripts/ci/build.sh` — **BUILD SUCCEEDED**
- [x] `pod spec lint` — spec valid (only failure is the not-yet-created git tag)
- [x] Version consistency: Version.swift == Payrails.podspec == 2.0.0

## Post-merge (manual)
1. Create GitHub Release — tag `v2.0.0`, target `main`, body = changelog above
2. CI auto-publishes to CocoaPods trunk; SPM picks up the tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)