### PR TITLE
ONB-768: Tokenize functionality  `session.tokenize()`

### DIFF
--- a/Payrails/Classes/Public/Domains/Callbacks.swift
+++ b/Payrails/Classes/Public/Domains/Callbacks.swift
@@ -2,6 +2,7 @@ import Foundation
 
 public typealias OnInitCallback = ((Result<Payrails.Session, PayrailsError>) -> Void)
 public typealias OnPayCallback = ((OnPayResult) -> Void)
+public typealias OnTokenizeCallback = ((OnTokenizeResult) -> Void)
 
 /// Closure the merchant provides at `Payrails.createSession` time. The SDK invokes it
 /// when it detects the current Payrails execution is no longer reusable — most commonly
@@ -62,6 +63,29 @@ public enum OnPayResult {
     /// Surfaced to the merchant via `onAuthorizePending`. No session refresh is triggered:
     /// the execution is still live and may settle later.
     case pending
+}
+
+/// Result delivered to `tokenize(_:presenter:options:onResult:)` — the callback-based
+/// counterpart to awaiting `tokenize(...)`. Mirrors `OnPayResult`'s shape, but `.success`
+/// carries the saved instrument and user cancellation is a first-class `.cancelled` case
+/// (instead of a thrown `CancellationError`).
+public enum OnTokenizeResult {
+    case success(SaveInstrumentResponse)
+    case cancelled
+    case failed(PayrailsError)
+}
+
+public extension OnTokenizeResult {
+    /// Maps a thrown tokenize error to the matching non-success case: a `CancellationError`
+    /// (the user dismissed the sheet) becomes `.cancelled`; anything else becomes `.failed`,
+    /// with non-`PayrailsError` errors wrapped in `.unknown(error:)`.
+    init(failure error: Error) {
+        if error is CancellationError {
+            self = .cancelled
+        } else {
+            self = .failed(error as? PayrailsError ?? .unknown(error: error))
+        }
+    }
 }
 
 /// Discriminating code for an authorization failure. Raw values match the Web SDK's

--- a/Payrails/Classes/Public/Domains/Callbacks.swift
+++ b/Payrails/Classes/Public/Domains/Callbacks.swift
@@ -2,7 +2,6 @@ import Foundation
 
 public typealias OnInitCallback = ((Result<Payrails.Session, PayrailsError>) -> Void)
 public typealias OnPayCallback = ((OnPayResult) -> Void)
-public typealias OnTokenizeCallback = ((OnTokenizeResult) -> Void)
 
 /// Closure the merchant provides at `Payrails.createSession` time. The SDK invokes it
 /// when it detects the current Payrails execution is no longer reusable — most commonly
@@ -65,17 +64,17 @@ public enum OnPayResult {
     case pending
 }
 
-/// Result delivered to `tokenize(_:presenter:options:onResult:)` — the callback-based
-/// counterpart to awaiting `tokenize(...)`. Mirrors `OnPayResult`'s shape, but `.success`
-/// carries the saved instrument and user cancellation is a first-class `.cancelled` case
-/// (instead of a thrown `CancellationError`).
-public enum OnTokenizeResult {
+/// Tokenize outcome — `.success` carries the saved instrument, `.cancelled` is the user dismissing
+/// the sheet (not a thrown `CancellationError`), and `.failed` carries the error. The callback-based
+/// `tokenize(_:options:onSuccess:onFailed:onCancelled:)` uses this to map a thrown error onto the
+/// matching outcome closure; the async `tokenize` returns / throws directly.
+enum OnTokenizeResult {
     case success(SaveInstrumentResponse)
     case cancelled
     case failed(PayrailsError)
 }
 
-public extension OnTokenizeResult {
+extension OnTokenizeResult {
     /// Maps a thrown tokenize error to the matching non-success case: a `CancellationError`
     /// (the user dismissed the sheet) becomes `.cancelled`; anything else becomes `.failed`,
     /// with non-`PayrailsError` errors wrapped in `.unknown(error:)`.

--- a/Payrails/Classes/Public/Domains/PaymentFlow.swift
+++ b/Payrails/Classes/Public/Domains/PaymentFlow.swift
@@ -135,6 +135,24 @@ struct SaveInstrumentBodyData: Encodable {
     var vaultProviderConfigId: String?
     var paymentToken: String?
 
+    // Construct only via the per-method factories below, so an empty or half-filled payload
+    // can't be built by accident at a call site.
+    private init(encryptedData: String? = nil, vaultProviderConfigId: String? = nil, paymentToken: String? = nil) {
+        self.encryptedData = encryptedData
+        self.vaultProviderConfigId = vaultProviderConfigId
+        self.paymentToken = paymentToken
+    }
+
+    /// Card create-instrument payload: vault ciphertext + the provider config that produced it.
+    static func card(encryptedData: String, vaultProviderConfigId: String) -> Self {
+        .init(encryptedData: encryptedData, vaultProviderConfigId: vaultProviderConfigId)
+    }
+
+    /// Wallet (Apple Pay) create-instrument payload: the stringified wallet payment token.
+    static func applePay(paymentToken: String) -> Self {
+        .init(paymentToken: paymentToken)
+    }
+
     // Backend-defined keys. `nil` fields are still omitted by JSONEncoder, so the card
     // (encryptedData + vaultProviderConfigId) and wallet (paymentToken) shapes stay mutually
     // exclusive — CodingKeys only pins the names, not which keys are emitted.

--- a/Payrails/Classes/Public/Domains/PaymentFlow.swift
+++ b/Payrails/Classes/Public/Domains/PaymentFlow.swift
@@ -114,11 +114,35 @@ struct SaveInstrumentBody: Encodable {
     let storeInstrument: Bool
     let futureUsage: String
     let data: SaveInstrumentBodyData
+
+    // Pin the wire keys explicitly so a Swift property rename can't silently change the
+    // backend payload. These names are the create-instrument contract, not Swift conventions.
+    enum CodingKeys: String, CodingKey {
+        case holderReference
+        case paymentMethod
+        case storeInstrument
+        case futureUsage
+        case data
+    }
 }
 
+/// Wire shape of the create-instrument `data` object. These keys are defined by the backend
+/// (and mirror the web-sdk): a **card** sends `encryptedData` (vault ciphertext) + `vaultProviderConfigId`;
+/// a **wallet** (Apple Pay) sends `paymentToken` (the stringified wallet payment). They're
+/// per-method and mutually exclusive — the JSON encoder omits the unused (nil) fields.
 struct SaveInstrumentBodyData: Encodable {
-    let encryptedData: String
-    let vaultProviderConfigId: String
+    var encryptedData: String?
+    var vaultProviderConfigId: String?
+    var paymentToken: String?
+
+    // Backend-defined keys. `nil` fields are still omitted by JSONEncoder, so the card
+    // (encryptedData + vaultProviderConfigId) and wallet (paymentToken) shapes stay mutually
+    // exclusive — CodingKeys only pins the names, not which keys are emitted.
+    enum CodingKeys: String, CodingKey {
+        case encryptedData
+        case vaultProviderConfigId
+        case paymentToken
+    }
 }
 
 public struct SaveInstrumentResponse: Decodable {

--- a/Payrails/Classes/Public/Domains/PaymentType.swift
+++ b/Payrails/Classes/Public/Domains/PaymentType.swift
@@ -4,4 +4,22 @@ public extension Payrails {
     enum PaymentType: String, Decodable {
         case payPal, applePay, card, genericRedirect
     }
+
+    /// What the merchant hands to `Session.tokenize` to say *which* instrument to tokenize and
+    /// *how*. One case per method, each carrying exactly what that method needs — so adding a
+    /// new method later (e.g. PayPal) is a new case and `tokenize`'s signature never changes.
+    ///
+    /// Unlike `PaymentType` (a wire-decodable `String` enum), this holds live runtime objects
+    /// (a presenter, the card form), so it is intentionally NOT `Decodable`.
+    enum TokenizationRequest {
+        /// Apple Pay: the SDK presents the PassKit sheet via `presenter`, then tokenizes the wallet token.
+        case applePay(presenter: PaymentPresenter)
+
+        /// Card: the SDK reads and encrypts the live fields from the merchant's embedded
+        /// `CardForm` — no presenter needed, the form is already on screen.
+        case card(CardForm)
+
+        // Future methods slot in here with no change to `tokenize`'s signature, e.g.:
+        // case payPal(presenter: PaymentPresenter)
+    }
 }

--- a/Payrails/Classes/Public/PaymentHelpers/ApplePayHandler.swift
+++ b/Payrails/Classes/Public/PaymentHelpers/ApplePayHandler.swift
@@ -1,21 +1,32 @@
 import Foundation
 import PassKit
+import Contacts
 
 class ApplePayHandler: NSObject {
+
+    /// Whether this handler runs a normal payment (authorize) or a tokenization
+    /// (save the instrument, no payment). Chosen once when the handler is created.
+    enum Mode {
+        case payment
+        case tokenize
+    }
 
     private let request = PKPaymentRequest()
     private weak var delegate: PaymentHandlerDelegate?
     private let saveInstrument: Bool
+    private let mode: Mode
 
     /// Set once the user authorizes (inside `didAuthorizePayment`). Lets `…DidFinish`
     /// tell a real pre-auth cancel from the dismissal that follows a successful
     /// payment (ONB-766).
     private var didAuthorize = false
+    private var finishAfterDismissal: ((ApplePayHandler) -> Void)?
 
     init(
         config: PaymentOptions.ApplePayConfig,
         delegate: PaymentHandlerDelegate?,
-        saveInstrument: Bool
+        saveInstrument: Bool,
+        mode: Mode = .payment
     ) {
         request.merchantIdentifier = config.parameters.merchantIdentifier
         request.supportedNetworks = config.parameters.supportedNetworks.paymentNetworks
@@ -25,6 +36,64 @@ class ApplePayHandler: NSObject {
         request.countryCode = config.parameters.countryCode
         self.delegate = delegate
         self.saveInstrument = saveInstrument
+        self.mode = mode
+    }
+
+    /// Serializes a `PKPayment` into the exact JSON string the backend's create-instrument
+    /// endpoint expects: the full `ApplePayPayment` shape
+    /// `{ billingContact, shippingContact, token: { paymentData, paymentMethod, transactionIdentifier } }`.
+    ///
+    /// NOTE: this is a DIFFERENT shape from the flattened payload the payment/authorize path
+    /// builds — do not confuse the two.
+    private func makeTokenizationPaymentToken(from payment: PKPayment) -> String? {
+        // `paymentData` is the encrypted-payment JSON; decode it so it nests as JSON
+        // (not as an escaped string) inside `token`.
+        guard let paymentDataObject = try? JSONSerialization.jsonObject(with: payment.token.paymentData) else {
+            return nil
+        }
+
+        let token: [String: Any] = [
+            "paymentData": paymentDataObject,
+            "paymentMethod": [
+                "displayName": payment.token.paymentMethod.displayName ?? "",
+                "network": payment.token.paymentMethod.network?.rawValue ?? "",
+                "type": "credit"
+            ],
+            "transactionIdentifier": payment.token.transactionIdentifier
+        ]
+
+        var root: [String: Any] = ["token": token]
+        // Contacts are best-effort: include them if Apple Pay provided them. If the backend
+        // turns out to require them, we expand the mapping here.
+        if let billing = payment.billingContact { root["billingContact"] = contactDict(billing) }
+        if let shipping = payment.shippingContact { root["shippingContact"] = contactDict(shipping) }
+
+        guard let data = try? JSONSerialization.data(withJSONObject: root),
+              let string = String(data: data, encoding: .utf8) else {
+            return nil
+        }
+        return string
+    }
+
+    // 9- [rev. question] : what does this function do ? what is the input and output of it ?
+    // This function takes a PKContact object (input) and converts it into a dictionary representation (output)
+    // suitable for JSON serialization. The dictionary includes the contact's name, email, and postal address.
+    private func contactDict(_ contact: PKContact) -> [String: Any] {
+        var dict: [String: Any] = [:]
+        if let given = contact.name?.givenName { dict["givenName"] = given }
+        if let family = contact.name?.familyName { dict["familyName"] = family }
+        if let email = contact.emailAddress { dict["emailAddress"] = email }
+        if let address = contact.postalAddress {
+            dict["addressLines"] = address.street.isEmpty ? [] : [address.street]
+            dict["locality"] = address.city
+            dict["subLocality"] = address.subLocality
+            dict["administrativeArea"] = address.state
+            dict["subAdministrativeArea"] = address.subAdministrativeArea
+            dict["postalCode"] = address.postalCode
+            dict["country"] = address.country
+            dict["countryCode"] = address.isoCountryCode
+        }
+        return dict
     }
 }
 
@@ -103,12 +172,22 @@ extension ApplePayHandler: PKPaymentAuthorizationViewControllerDelegate {
     func paymentAuthorizationViewControllerDidFinish(
         _ controller: PKPaymentAuthorizationViewController
     ) {
-        controller.dismiss(animated: true)
-        // If authorization already happened, the success/error path is in flight from
-        // didAuthorizePayment — don't report a spurious cancel here (ONB-766).
-        guard !didAuthorize else { return }
-        // No authorization observed → a genuine pre-auth cancel (user tapped X / swiped down).
-        delegate?.paymentHandlerDidFinish(handler: self, type: .applePay, status: .canceled, payload: nil)
+        dismiss(controller) { [weak self] in
+            guard let self else { return }
+
+            if self.didAuthorize {
+                let finish = self.finishAfterDismissal
+                self.finishAfterDismissal = nil
+                finish?(self)
+                return
+            }
+
+            if self.mode == .tokenize {
+                self.delegate?.paymentHandlerDidFailTokenization(handler: self, error: CancellationError())
+            } else {
+                self.delegate?.paymentHandlerDidFinish(handler: self, type: .applePay, status: .canceled, payload: nil)
+            }
+        }
     }
 
     func paymentAuthorizationViewController(
@@ -117,13 +196,59 @@ extension ApplePayHandler: PKPaymentAuthorizationViewControllerDelegate {
         handler paymentCompletion: @escaping (PKPaymentAuthorizationResult) -> Void
     ) {
         didAuthorize = true
-        guard let paymentData = try? JSONSerialization.jsonObject(with: payment.token.paymentData) else {
-            delegate?.paymentHandlerDidFinish(
+
+        // TOKENIZE flow: route the token to the create-instrument call and KEEP the sheet
+        // open (don't call paymentCompletion yet). We complete only when tokenization returns,
+        // so a failed tokenize shows as an error in the sheet instead of a false success.
+        // 8- [rev. question] : Does this mean that a failed tokenization will necessarily make the payment fail ?
+        if mode == .tokenize {
+            guard let paymentToken = makeTokenizationPaymentToken(from: payment) else {
+                // 9- [rev. question] : Do we actaully need to make the payment fail due to serialization failure ? or we can just report the error to the delegate and let it decide how to handle it ?
+                // 10- [rev. question] : what finish finishAfterDismissal do ? 
+                finishAfterDismissal = { handler in
+                    handler.delegate?.paymentHandlerDidFailTokenization(
+                        handler: handler,
+                        error: PayrailsError.invalidDataFormat
+                    )
+                }
+                paymentCompletion(.init(status: .failure, errors: nil))
+                return
+            }
+            delegate?.paymentHandlerDidRequestTokenization(
                 handler: self,
-                type: .applePay,
-                status: .error(nil),
-                payload: nil
-            )
+                paymentToken: paymentToken
+            ) { [weak self] result in
+                guard let self else { return }
+                let tokenizationResult = result.mapError { $0 as Error }
+                self.finishAfterDismissal = { handler in
+                    handler.delegate?.paymentHandlerDidFinishTokenization(
+                        handler: handler,
+                        result: tokenizationResult
+                    )
+                }
+                switch result {
+                case .success:
+                    paymentCompletion(.init(status: .success, errors: nil))
+                case .failure:
+                    paymentCompletion(.init(status: .failure, errors: nil))
+                }
+            }
+            return
+        }
+
+        // PAYMENT flow: build the authorize payload, but do not notify the session until the
+        // Apple Pay controller has completed its dismissal. Starting the next UIKit/network
+        // phase while PassKit is still dismissing can leave the host app unable to present
+        // navigation UI immediately after the sheet closes.
+        guard let paymentData = try? JSONSerialization.jsonObject(with: payment.token.paymentData) else {
+            finishAfterDismissal = { handler in
+                handler.delegate?.paymentHandlerDidFinish(
+                    handler: handler,
+                    type: .applePay,
+                    status: .error(nil),
+                    payload: nil
+                )
+            }
             paymentCompletion(.init(status: .failure, errors: nil))
             return
         }
@@ -142,28 +267,57 @@ extension ApplePayHandler: PKPaymentAuthorizationViewControllerDelegate {
         ]
 
         guard let payloadData = try? JSONSerialization.data(withJSONObject: payload, options: []) else {
-            delegate?.paymentHandlerDidFinish(
-                handler: self,
-                type: .applePay,
-                status: .error(nil),
-                payload: nil
-            )
+            finishAfterDismissal = { handler in
+                handler.delegate?.paymentHandlerDidFinish(
+                    handler: handler,
+                    type: .applePay,
+                    status: .error(nil),
+                    payload: nil
+                )
+            }
             paymentCompletion(.init(status: .failure, errors: nil))
             return
         }
 
-        delegate?.paymentHandlerDidFinish(
-            handler: self,
-            type: .applePay,
-            status: .success,
-            payload: [
-                "paymentInstrumentData": [
-                    "paymentToken": String(data: payloadData, encoding: String.Encoding.utf8)
-                ]
+        let successPayload: [String: Any] = [
+            "paymentInstrumentData": [
+                "paymentToken": String(data: payloadData, encoding: String.Encoding.utf8)
             ]
-        )
+        ]
+        finishAfterDismissal = { handler in
+            handler.delegate?.paymentHandlerDidFinish(
+                handler: handler,
+                type: .applePay,
+                status: .success,
+                payload: successPayload
+            )
+        }
 
         paymentCompletion(.init(status: .success, errors: nil))
+    }
+
+    private func dismiss(
+        _ controller: PKPaymentAuthorizationViewController,
+        completion: @escaping () -> Void
+    ) {
+        let complete = {
+            if Thread.isMainThread {
+                completion()
+            } else {
+                DispatchQueue.main.async(execute: completion)
+            }
+        }
+
+        DispatchQueue.main.async {
+            guard controller.presentingViewController != nil else {
+                complete()
+                return
+            }
+
+            controller.dismiss(animated: true) {
+                complete()
+            }
+        }
     }
 }
 

--- a/Payrails/Classes/Public/PaymentHelpers/ApplePayHandler.swift
+++ b/Payrails/Classes/Public/PaymentHelpers/ApplePayHandler.swift
@@ -75,9 +75,7 @@ class ApplePayHandler: NSObject {
         return string
     }
 
-    // 9- [rev. question] : what does this function do ? what is the input and output of it ?
-    // This function takes a PKContact object (input) and converts it into a dictionary representation (output)
-    // suitable for JSON serialization. The dictionary includes the contact's name, email, and postal address.
+    /// Converts a `PKContact` into a JSON-serializable dictionary of name, email, and postal address.
     private func contactDict(_ contact: PKContact) -> [String: Any] {
         var dict: [String: Any] = [:]
         if let given = contact.name?.givenName { dict["givenName"] = given }
@@ -182,11 +180,24 @@ extension ApplePayHandler: PKPaymentAuthorizationViewControllerDelegate {
                 return
             }
 
-            if self.mode == .tokenize {
-                self.delegate?.paymentHandlerDidFailTokenization(handler: self, error: CancellationError())
-            } else {
-                self.delegate?.paymentHandlerDidFinish(handler: self, type: .applePay, status: .canceled, payload: nil)
-            }
+            // didAuthorize == false: the user dismissed the sheet before authorizing. No token or
+            // payment processing has started yet, so nothing could have failed — this is a
+            // cancellation, reported through the channel that matches the active flow.
+            self.notifyCancellation()
+        }
+    }
+
+    /// Reports a user cancellation (sheet dismissed without authorizing) to the delegate, via the
+    /// terminal channel appropriate to the active flow:
+    /// - `.tokenize`: resumes the awaiting async `tokenize()` by throwing `CancellationError`
+    ///   (Swift's "cancelled, not an error" sentinel).
+    /// - `.payment`: delivers a `.canceled` status to the payment completion handler.
+    private func notifyCancellation() {
+        switch mode {
+        case .tokenize:
+            delegate?.paymentHandlerDidFailTokenization(handler: self, error: CancellationError())
+        case .payment:
+            delegate?.paymentHandlerDidFinish(handler: self, type: .applePay, status: .canceled, payload: nil)
         }
     }
 
@@ -200,11 +211,8 @@ extension ApplePayHandler: PKPaymentAuthorizationViewControllerDelegate {
         // TOKENIZE flow: route the token to the create-instrument call and KEEP the sheet
         // open (don't call paymentCompletion yet). We complete only when tokenization returns,
         // so a failed tokenize shows as an error in the sheet instead of a false success.
-        // 8- [rev. question] : Does this mean that a failed tokenization will necessarily make the payment fail ?
         if mode == .tokenize {
             guard let paymentToken = makeTokenizationPaymentToken(from: payment) else {
-                // 9- [rev. question] : Do we actaully need to make the payment fail due to serialization failure ? or we can just report the error to the delegate and let it decide how to handle it ?
-                // 10- [rev. question] : what finish finishAfterDismissal do ? 
                 finishAfterDismissal = { handler in
                     handler.delegate?.paymentHandlerDidFailTokenization(
                         handler: handler,

--- a/Payrails/Classes/Public/PaymentHelpers/ApplePayHandler.swift
+++ b/Payrails/Classes/Public/PaymentHelpers/ApplePayHandler.swift
@@ -54,11 +54,7 @@ class ApplePayHandler: NSObject {
 
         let token: [String: Any] = [
             "paymentData": paymentDataObject,
-            "paymentMethod": [
-                "displayName": payment.token.paymentMethod.displayName ?? "",
-                "network": payment.token.paymentMethod.network?.rawValue ?? "",
-                "type": "credit"
-            ],
+            "paymentMethod": paymentMethodDict(from: payment),
             "transactionIdentifier": payment.token.transactionIdentifier
         ]
 
@@ -73,6 +69,27 @@ class ApplePayHandler: NSObject {
             return nil
         }
         return string
+    }
+
+    /// Maps Apple Pay's `PKPaymentMethodType` to the backend's instrument `type` string, so
+    /// debit / prepaid / store cards aren't all mis-reported to the backend as "credit".
+    private func paymentMethodTypeString(_ type: PKPaymentMethodType) -> String {
+        switch type {
+        case .credit:  return "credit"
+        case .debit:   return "debit"
+        case .prepaid: return "prepaid"
+        case .store:   return "store"
+        default:       return "unknown"
+        }
+    }
+
+    /// The `paymentMethod` sub-object shared by the tokenize token and the authorize payload.
+    private func paymentMethodDict(from payment: PKPayment) -> [String: Any] {
+        [
+            "displayName": payment.token.paymentMethod.displayName ?? "",
+            "network": payment.token.paymentMethod.network?.rawValue ?? "",
+            "type": paymentMethodTypeString(payment.token.paymentMethod.type)
+        ]
     }
 
     /// Converts a `PKContact` into a JSON-serializable dictionary of name, email, and postal address.
@@ -195,7 +212,7 @@ extension ApplePayHandler: PKPaymentAuthorizationViewControllerDelegate {
     private func notifyCancellation() {
         switch mode {
         case .tokenize:
-            delegate?.paymentHandlerDidFailTokenization(handler: self, error: CancellationError())
+            delegate?.paymentHandlerDidFinishTokenization(handler: self, result: .failure(CancellationError()))
         case .payment:
             delegate?.paymentHandlerDidFinish(handler: self, type: .applePay, status: .canceled, payload: nil)
         }
@@ -214,9 +231,9 @@ extension ApplePayHandler: PKPaymentAuthorizationViewControllerDelegate {
         if mode == .tokenize {
             guard let paymentToken = makeTokenizationPaymentToken(from: payment) else {
                 finishAfterDismissal = { handler in
-                    handler.delegate?.paymentHandlerDidFailTokenization(
+                    handler.delegate?.paymentHandlerDidFinishTokenization(
                         handler: handler,
-                        error: PayrailsError.invalidDataFormat
+                        result: .failure(PayrailsError.invalidDataFormat)
                     )
                 }
                 paymentCompletion(.init(status: .failure, errors: nil))
@@ -264,11 +281,7 @@ extension ApplePayHandler: PKPaymentAuthorizationViewControllerDelegate {
         // Create the restructured payload with paymentMethod object
         let payload: [String: Any] = [
             "paymentData": paymentData,
-            "paymentMethod": [
-                "displayName": payment.token.paymentMethod.displayName ?? "",
-                "network": payment.token.paymentMethod.network?.rawValue ?? "",
-                "type": "credit"
-            ],
+            "paymentMethod": paymentMethodDict(from: payment),
             "transactionIdentifier": payment.token.transactionIdentifier,
             "paymentNetwork": payment.token.paymentMethod.network?.rawValue ?? "",
             "paymentInstrumentName": payment.token.paymentMethod.displayName ?? ""

--- a/Payrails/Classes/Public/PayrailsSession.swift
+++ b/Payrails/Classes/Public/PayrailsSession.swift
@@ -10,7 +10,6 @@ public extension Payrails {
         var executionId: String?
 
         private var onResult: OnPayCallback?
-        // 2- [rev. question] : what does these two properties do ? applePayTokenizeContinuation and applePayTokenizeOptions
         /// Bridges the Apple Pay sheet's delegate callbacks back into the `async tokenize`
         /// call: held while the sheet is open, resumed exactly once when tokenization
         /// finishes, fails, or the user cancels.
@@ -208,8 +207,6 @@ public extension Payrails {
         /// Presents the Apple Pay sheet in TOKENIZE mode. The outcome flows back through the
         /// PaymentHandlerDelegate callbacks, which resume `applePayTokenizeContinuation`.
         private func presentApplePayTokenizationSheet(presenter: PaymentPresenter?) {
-            // 3- [rev. question] : what the config is ?
-            // 4- [rev. question] : is the paymentComposition here is coming from the /init response ?
             guard let paymentComposition = config.paymentOption(for: .applePay),
                   case let .applePay(applePayConfig) = paymentComposition.config else {
                 finishApplePayTokenization(with: .failure(PayrailsError.unsupportedPayment(type: .applePay)))
@@ -220,13 +217,10 @@ public extension Payrails {
                 return
             }
 
-            // 5- [rev. question] : Do we call the payment handler here to present the apple pay sheet ?
             let handler = ApplePayHandler(
                 config: applePayConfig,
                 delegate: self,
                 saveInstrument: true,
-                // 6- [rev. question] : what does this `mode` do ? this is to instruct the sheet to show the sheet to obtina apple pay token ?
-                // 7- [rev. question] : where this property `mode` is declared ?
                 mode: .tokenize
             )
             self.paymentHandler = handler
@@ -955,6 +949,26 @@ extension Payrails.Session {
         case .card, .payPal, .genericRedirect:
             // Not tokenizable via a presented sheet here. Cards use `cardForm.tokenize()`.
             throw PayrailsError.unsupportedPayment(type: method)
+        }
+    }
+
+    /// Callback-based counterpart to `tokenize(_:presenter:options:)` — the same flow delivered
+    /// through an `onResult` closure (matching `executePayment`) instead of `async/await`, for
+    /// merchants not using structured concurrency. The closure is invoked exactly once, on the
+    /// main thread; user cancellation arrives as `.cancelled` rather than a thrown error.
+    public func tokenize(
+        _ method: Payrails.PaymentType,
+        presenter: PaymentPresenter,
+        options: TokenizeOptions = TokenizeOptions(),
+        onResult: @escaping OnTokenizeCallback
+    ) {
+        Task { @MainActor in
+            do {
+                let response = try await self.tokenize(method, presenter: presenter, options: options)
+                onResult(.success(response))
+            } catch {
+                onResult(OnTokenizeResult(failure: error))
+            }
         }
     }
 

--- a/Payrails/Classes/Public/PayrailsSession.swift
+++ b/Payrails/Classes/Public/PayrailsSession.swift
@@ -13,8 +13,8 @@ public extension Payrails {
         /// Bridges the Apple Pay sheet's delegate callbacks back into the `async tokenize`
         /// call: held while the sheet is open, resumed exactly once when tokenization
         /// finishes, fails, or the user cancels.
-        private var applePayTokenizeContinuation: CheckedContinuation<SaveInstrumentResponse, Error>?
-        private var applePayTokenizeOptions = TokenizeOptions()
+        private var tokenizeContinuation: CheckedContinuation<SaveInstrumentResponse, Error>?
+        private var tokenizeOptions = TokenizeOptions()
         private var paymentHandler: PaymentHandler?
         private var currentTask: Task<Void, Error>?
         private var payrailsCSE: PayrailsCSE?
@@ -205,15 +205,15 @@ public extension Payrails {
         }
 
         /// Presents the Apple Pay sheet in TOKENIZE mode. The outcome flows back through the
-        /// PaymentHandlerDelegate callbacks, which resume `applePayTokenizeContinuation`.
+        /// PaymentHandlerDelegate callbacks, which resume `tokenizeContinuation`.
         private func presentApplePayTokenizationSheet(presenter: PaymentPresenter?) {
             guard let paymentComposition = config.paymentOption(for: .applePay),
                   case let .applePay(applePayConfig) = paymentComposition.config else {
-                finishApplePayTokenization(with: .failure(PayrailsError.unsupportedPayment(type: .applePay)))
+                finishTokenization(with: .failure(PayrailsError.unsupportedPayment(type: .applePay)))
                 return
             }
             guard let total = Double(config.amount.value) else {
-                finishApplePayTokenization(with: .failure(PayrailsError.invalidDataFormat))
+                finishTokenization(with: .failure(PayrailsError.invalidDataFormat))
                 return
             }
 
@@ -228,9 +228,9 @@ public extension Payrails {
         }
 
         /// Resumes the pending tokenization continuation exactly once, then clears state.
-        private func finishApplePayTokenization(with result: Result<SaveInstrumentResponse, Error>) {
-            applePayTokenizeContinuation?.resume(with: result)
-            applePayTokenizeContinuation = nil
+        private func finishTokenization(with result: Result<SaveInstrumentResponse, Error>) {
+            tokenizeContinuation?.resume(with: result)
+            tokenizeContinuation = nil
             paymentHandler = nil
         }
 
@@ -465,8 +465,8 @@ extension Payrails.Session: PaymentHandlerDelegate {
             do {
                 let response = try await self.saveInstrument(
                     paymentMethod: "applePay",
-                    data: SaveInstrumentBodyData(paymentToken: paymentToken),
-                    options: self.applePayTokenizeOptions
+                    data: .applePay(paymentToken: paymentToken),
+                    options: self.tokenizeOptions
                 )
                 await MainActor.run {
                     completion(.success(response))
@@ -484,13 +484,7 @@ extension Payrails.Session: PaymentHandlerDelegate {
         handler: PaymentHandler,
         result: Result<SaveInstrumentResponse, Error>
     ) {
-        finishApplePayTokenization(with: result)
-    }
-
-    /// Tokenization ended without a usable token (user dismissed the sheet, or serialization
-    /// failed). Resume the awaiting `tokenize` call by throwing.
-    func paymentHandlerDidFailTokenization(handler: PaymentHandler, error: Error) {
-        finishApplePayTokenization(with: .failure(error))
+        finishTokenization(with: result)
     }
 
     /// Called when the user interactively dismissed the 3DS challenge (e.g. swipe-down on
@@ -927,61 +921,71 @@ extension Payrails.Session {
     /// capturing the token, and saving the instrument. Returns the saved instrument (use `.id`
     /// for the stable Payrails instrument id).
     ///
-    /// Only methods the SDK tokenizes via presented UI are supported (currently `.applePay`).
-    /// Cards tokenize via `cardForm.tokenize()`; other methods throw `.unsupportedPayment`.
+    /// `request` selects the method and carries what it needs: `.applePay(presenter:)` presents
+    /// the PassKit sheet; `.card(cardForm)` reads and encrypts the embedded form. Adding a method
+    /// later is a new `TokenizationRequest` case — this signature does not change.
     public func tokenize(
-        _ method: Payrails.PaymentType,
-        presenter: PaymentPresenter,
+        _ request: Payrails.TokenizationRequest,
         options: TokenizeOptions = TokenizeOptions()
     ) async throws -> SaveInstrumentResponse {
-        switch method {
-        case .applePay:
+        switch request {
+        case let .applePay(presenter):
             // Bridge the Apple Pay sheet's delegate callbacks into async/await. The continuation
             // is resumed (once) from the PaymentHandlerDelegate methods — AFTER the
             // create-instrument POST completes — so the sheet stays open across it.
-            self.applePayTokenizeOptions = options
+            self.tokenizeOptions = options
             return try await withCheckedThrowingContinuation { continuation in
-                self.applePayTokenizeContinuation = continuation
+                self.tokenizeContinuation = continuation
                 Task { @MainActor in
                     self.presentApplePayTokenizationSheet(presenter: presenter)
                 }
             }
-        case .card, .payPal, .genericRedirect:
-            // Not tokenizable via a presented sheet here. Cards use `cardForm.tokenize()`.
-            throw PayrailsError.unsupportedPayment(type: method)
+        case let .card(cardForm):
+            // Card: the form collects + encrypts its live fields (it owns the PAN / PCI boundary),
+            // then we save through the shared core. `CardForm.tokenize()` routes back into here, so
+            // this MUST call `encryptCardData()` — never `cardForm.tokenize()` — or it would loop.
+            let encryptedData = try await cardForm.encryptCardData()
+            return try await self.tokenize(encryptedData: encryptedData, options: options)
         }
     }
 
-    /// Callback-based counterpart to `tokenize(_:presenter:options:)` — the same flow delivered
-    /// through an `onResult` closure (matching `executePayment`) instead of `async/await`, for
-    /// merchants not using structured concurrency. The closure is invoked exactly once, on the
-    /// main thread; user cancellation arrives as `.cancelled` rather than a thrown error.
+    /// Callback-based counterpart to `tokenize(_:options:)` — the same flow delivered through
+    /// outcome closures instead of `async/await`, for merchants not using structured concurrency.
+    /// Exactly one closure is invoked, once, on the main thread: `onSuccess` with the saved
+    /// instrument, `onFailed` with the error, or `onCancelled` if the user dismissed the sheet.
     public func tokenize(
-        _ method: Payrails.PaymentType,
-        presenter: PaymentPresenter,
+        _ request: Payrails.TokenizationRequest,
         options: TokenizeOptions = TokenizeOptions(),
-        onResult: @escaping OnTokenizeCallback
+        onSuccess: @escaping (SaveInstrumentResponse) -> Void,
+        onFailed: @escaping (PayrailsError) -> Void,
+        onCancelled: @escaping () -> Void
     ) {
         Task { @MainActor in
             do {
-                let response = try await self.tokenize(method, presenter: presenter, options: options)
-                onResult(.success(response))
+                let response = try await self.tokenize(request, options: options)
+                onSuccess(response)
             } catch {
-                onResult(OnTokenizeResult(failure: error))
+                // Reuse the single source of truth for error → outcome mapping
+                // (CancellationError → cancelled, PayrailsError → failed, else → failed(.unknown)).
+                switch OnTokenizeResult(failure: error) {
+                case .cancelled:                 onCancelled()
+                case .failed(let payrailsError): onFailed(payrailsError)
+                case .success:                   break // unreachable: the catch path never yields success
+                }
             }
         }
     }
 
-    /// Card tokenization entry point (called by `CardForm.tokenize()`). Independent of the
-    /// wallet `tokenize(_:presenter:)` path — cards have their own embedded-form collection, so
-    /// this stays the single source of truth for card tokenization.
+    /// Shared card-tokenization core: turns the vault ciphertext into a saved instrument via the
+    /// instruments endpoint. Reached from the `.card` branch of `tokenize(_:options:)` once the
+    /// form has encrypted its fields; the single source of truth for the card POST.
     func tokenize(encryptedData: String, options: TokenizeOptions) async throws -> SaveInstrumentResponse {
         guard let providerConfigId = config?.vaultConfiguration?.providerConfigId else {
             throw PayrailsError.missingData("Vault configuration with providerConfigId is required for card tokenization.")
         }
         return try await saveInstrument(
             paymentMethod: "card",
-            data: SaveInstrumentBodyData(encryptedData: encryptedData, vaultProviderConfigId: providerConfigId),
+            data: .card(encryptedData: encryptedData, vaultProviderConfigId: providerConfigId),
             options: options
         )
     }

--- a/Payrails/Classes/Public/PayrailsSession.swift
+++ b/Payrails/Classes/Public/PayrailsSession.swift
@@ -10,6 +10,12 @@ public extension Payrails {
         var executionId: String?
 
         private var onResult: OnPayCallback?
+        // 2- [rev. question] : what does these two properties do ? applePayTokenizeContinuation and applePayTokenizeOptions
+        /// Bridges the Apple Pay sheet's delegate callbacks back into the `async tokenize`
+        /// call: held while the sheet is open, resumed exactly once when tokenization
+        /// finishes, fails, or the user cancels.
+        private var applePayTokenizeContinuation: CheckedContinuation<SaveInstrumentResponse, Error>?
+        private var applePayTokenizeOptions = TokenizeOptions()
         private var paymentHandler: PaymentHandler?
         private var currentTask: Task<Void, Error>?
         private var payrailsCSE: PayrailsCSE?
@@ -197,6 +203,41 @@ public extension Payrails {
             }
 
             paymentHandler.makePayment(total: total, currency: config.amount.currency, presenter: presenter)
+        }
+
+        /// Presents the Apple Pay sheet in TOKENIZE mode. The outcome flows back through the
+        /// PaymentHandlerDelegate callbacks, which resume `applePayTokenizeContinuation`.
+        private func presentApplePayTokenizationSheet(presenter: PaymentPresenter?) {
+            // 3- [rev. question] : what the config is ?
+            // 4- [rev. question] : is the paymentComposition here is coming from the /init response ?
+            guard let paymentComposition = config.paymentOption(for: .applePay),
+                  case let .applePay(applePayConfig) = paymentComposition.config else {
+                finishApplePayTokenization(with: .failure(PayrailsError.unsupportedPayment(type: .applePay)))
+                return
+            }
+            guard let total = Double(config.amount.value) else {
+                finishApplePayTokenization(with: .failure(PayrailsError.invalidDataFormat))
+                return
+            }
+
+            // 5- [rev. question] : Do we call the payment handler here to present the apple pay sheet ?
+            let handler = ApplePayHandler(
+                config: applePayConfig,
+                delegate: self,
+                saveInstrument: true,
+                // 6- [rev. question] : what does this `mode` do ? this is to instruct the sheet to show the sheet to obtina apple pay token ?
+                // 7- [rev. question] : where this property `mode` is declared ?
+                mode: .tokenize
+            )
+            self.paymentHandler = handler
+            handler.makePayment(total: total, currency: config.amount.currency, presenter: presenter)
+        }
+
+        /// Resumes the pending tokenization continuation exactly once, then clears state.
+        private func finishApplePayTokenization(with result: Result<SaveInstrumentResponse, Error>) {
+            applePayTokenizeContinuation?.resume(with: result)
+            applePayTokenizeContinuation = nil
+            paymentHandler = nil
         }
 
         func cancelPayment() {
@@ -415,6 +456,47 @@ extension Payrails.Session: PaymentHandlerDelegate {
         isPaymentInProgress = false
         onResult?(.authorizationFailed(.unknownError(error)))
         paymentHandler = nil
+    }
+
+    /// Handler captured an Apple Pay token in tokenize mode. Save it via the shared core,
+    /// then close the sheet (`completion`). The awaiting `tokenize` call resumes only after
+    /// Apple Pay reports that its controller has fully dismissed.
+    func paymentHandlerDidRequestTokenization(
+        handler: PaymentHandler,
+        paymentToken: String,
+        completion: @escaping (Result<SaveInstrumentResponse, PayrailsError>) -> Void
+    ) {
+        Task { [weak self] in
+            guard let self = self else { return }
+            do {
+                let response = try await self.saveInstrument(
+                    paymentMethod: "applePay",
+                    data: SaveInstrumentBodyData(paymentToken: paymentToken),
+                    options: self.applePayTokenizeOptions
+                )
+                await MainActor.run {
+                    completion(.success(response))
+                }
+            } catch {
+                let payrailsError = (error as? PayrailsError) ?? .unknown(error: error)
+                await MainActor.run {
+                    completion(.failure(payrailsError))
+                }
+            }
+        }
+    }
+
+    func paymentHandlerDidFinishTokenization(
+        handler: PaymentHandler,
+        result: Result<SaveInstrumentResponse, Error>
+    ) {
+        finishApplePayTokenization(with: result)
+    }
+
+    /// Tokenization ended without a usable token (user dismissed the sheet, or serialization
+    /// failed). Resume the awaiting `tokenize` call by throwing.
+    func paymentHandlerDidFailTokenization(handler: PaymentHandler, error: Error) {
+        finishApplePayTokenization(with: .failure(error))
     }
 
     /// Called when the user interactively dismissed the 3DS challenge (e.g. swipe-down on
@@ -847,26 +929,67 @@ extension Payrails.Session {
         return try await payrailsAPI.updateInstrument(instrumentId: instrumentId, body: body)
     }
 
+    /// Tokenizes a payment method by presenting the SDK's own UI (e.g. the Apple Pay sheet),
+    /// capturing the token, and saving the instrument. Returns the saved instrument (use `.id`
+    /// for the stable Payrails instrument id).
+    ///
+    /// Only methods the SDK tokenizes via presented UI are supported (currently `.applePay`).
+    /// Cards tokenize via `cardForm.tokenize()`; other methods throw `.unsupportedPayment`.
+    public func tokenize(
+        _ method: Payrails.PaymentType,
+        presenter: PaymentPresenter,
+        options: TokenizeOptions = TokenizeOptions()
+    ) async throws -> SaveInstrumentResponse {
+        switch method {
+        case .applePay:
+            // Bridge the Apple Pay sheet's delegate callbacks into async/await. The continuation
+            // is resumed (once) from the PaymentHandlerDelegate methods — AFTER the
+            // create-instrument POST completes — so the sheet stays open across it.
+            self.applePayTokenizeOptions = options
+            return try await withCheckedThrowingContinuation { continuation in
+                self.applePayTokenizeContinuation = continuation
+                Task { @MainActor in
+                    self.presentApplePayTokenizationSheet(presenter: presenter)
+                }
+            }
+        case .card, .payPal, .genericRedirect:
+            // Not tokenizable via a presented sheet here. Cards use `cardForm.tokenize()`.
+            throw PayrailsError.unsupportedPayment(type: method)
+        }
+    }
+
+    /// Card tokenization entry point (called by `CardForm.tokenize()`). Independent of the
+    /// wallet `tokenize(_:presenter:)` path — cards have their own embedded-form collection, so
+    /// this stays the single source of truth for card tokenization.
     func tokenize(encryptedData: String, options: TokenizeOptions) async throws -> SaveInstrumentResponse {
         guard let providerConfigId = config?.vaultConfiguration?.providerConfigId else {
-            throw PayrailsError.missingData("Vault configuration with providerConfigId is required for tokenization.")
+            throw PayrailsError.missingData("Vault configuration with providerConfigId is required for card tokenization.")
         }
+        return try await saveInstrument(
+            paymentMethod: "card",
+            data: SaveInstrumentBodyData(encryptedData: encryptedData, vaultProviderConfigId: providerConfigId),
+            options: options
+        )
+    }
 
+    /// Shared tokenization core: builds the request body and POSTs to the instruments
+    /// endpoint (`POST /public/payment/instruments`). Used by BOTH the card and wallet paths,
+    /// so the POST logic exists exactly once. The backend routes by `paymentMethod`.
+    private func saveInstrument(
+        paymentMethod: String,
+        data: SaveInstrumentBodyData,
+        options: TokenizeOptions
+    ) async throws -> SaveInstrumentResponse {
         guard let holderReference = config?.holderReference else {
             throw PayrailsError.missingData("holderReference is required for tokenization.")
         }
-
         let body = SaveInstrumentBody(
             holderReference: holderReference,
-            paymentMethod: "card",
+            paymentMethod: paymentMethod,
             storeInstrument: options.storeInstrument,
             futureUsage: options.futureUsage.rawValue,
-            data: SaveInstrumentBodyData(
-                encryptedData: encryptedData,
-                vaultProviderConfigId: providerConfigId
-            )
+            data: data
         )
-
         return try await payrailsAPI.saveInstrument(body: body)
     }
 

--- a/Payrails/Classes/Public/Protocols/PaymentHandlerDelegate.swift
+++ b/Payrails/Classes/Public/Protocols/PaymentHandlerDelegate.swift
@@ -36,17 +36,14 @@ protocol PaymentHandlerDelegate: AnyObject {
         completion: @escaping (Result<SaveInstrumentResponse, PayrailsError>) -> Void
     )
 
-    /// Fired after the tokenization sheet has fully dismissed. Lets the session resume the
-    /// awaiting `tokenize` call only after UIKit has completed the Apple Pay transition.
+    /// Fired once a tokenization reaches a terminal outcome, AFTER the sheet has fully dismissed.
+    /// `result` carries either the saved instrument (`.success`) or the reason it ended without
+    /// one (`.failure` — the user cancelled the sheet, or the token couldn't be serialized). Lets
+    /// the session resume the awaiting `tokenize` call only after UIKit has completed the transition.
     func paymentHandlerDidFinishTokenization(
         handler: PaymentHandler,
         result: Result<SaveInstrumentResponse, Error>
     )
-
-    /// Fired when a tokenization ended WITHOUT a usable token — the user dismissed the sheet
-    /// (cancel) or serialization failed. Lets the session resume the awaiting `tokenize` call
-    /// by throwing, instead of leaving it suspended forever.
-    func paymentHandlerDidFailTokenization(handler: PaymentHandler, error: Error)
 }
 
 extension PaymentHandlerDelegate {
@@ -65,8 +62,6 @@ extension PaymentHandlerDelegate {
         handler: PaymentHandler,
         result: Result<SaveInstrumentResponse, Error>
     ) {}
-
-    func paymentHandlerDidFailTokenization(handler: PaymentHandler, error: Error) {}
 }
 
 enum PaymentHandlerStatus {

--- a/Payrails/Classes/Public/Protocols/PaymentHandlerDelegate.swift
+++ b/Payrails/Classes/Public/Protocols/PaymentHandlerDelegate.swift
@@ -26,10 +26,47 @@ protocol PaymentHandlerDelegate: AnyObject {
     /// see if the backend has actually committed a terminal status, then report cancellation
     /// if not.
     func paymentHandlerUserDidDismissChallenge(handler: PaymentHandler)
+
+    /// Fired by a handler when the user authorized a TOKENIZATION (not a payment). The
+    /// session turns `paymentToken` into a saved instrument and reports the result back via
+    /// `completion`. The handler holds its Apple Pay sheet open until `completion` runs.
+    func paymentHandlerDidRequestTokenization(
+        handler: PaymentHandler,
+        paymentToken: String,
+        completion: @escaping (Result<SaveInstrumentResponse, PayrailsError>) -> Void
+    )
+
+    /// Fired after the tokenization sheet has fully dismissed. Lets the session resume the
+    /// awaiting `tokenize` call only after UIKit has completed the Apple Pay transition.
+    func paymentHandlerDidFinishTokenization(
+        handler: PaymentHandler,
+        result: Result<SaveInstrumentResponse, Error>
+    )
+
+    /// Fired when a tokenization ended WITHOUT a usable token — the user dismissed the sheet
+    /// (cancel) or serialization failed. Lets the session resume the awaiting `tokenize` call
+    /// by throwing, instead of leaving it suspended forever.
+    func paymentHandlerDidFailTokenization(handler: PaymentHandler, error: Error)
 }
 
 extension PaymentHandlerDelegate {
     func paymentHandlerUserDidDismissChallenge(handler: PaymentHandler) {}
+
+    // Defaults keep non-tokenizing handlers unaffected; the Session overrides these.
+    func paymentHandlerDidRequestTokenization(
+        handler: PaymentHandler,
+        paymentToken: String,
+        completion: @escaping (Result<SaveInstrumentResponse, PayrailsError>) -> Void
+    ) {
+        completion(.failure(.unsupportedPayment(type: .applePay)))
+    }
+
+    func paymentHandlerDidFinishTokenization(
+        handler: PaymentHandler,
+        result: Result<SaveInstrumentResponse, Error>
+    ) {}
+
+    func paymentHandlerDidFailTokenization(handler: PaymentHandler, error: Error) {}
 }
 
 enum PaymentHandlerStatus {

--- a/Payrails/Classes/Public/Vault/elements/TextField.swift
+++ b/Payrails/Classes/Public/Vault/elements/TextField.swift
@@ -285,7 +285,7 @@ public class TextField: SkyflowElement, Element, BaseElement {
          updateStyle(update.inputStyles.empty, &collectInput.inputStyles.empty)
          updateStyle(update.inputStyles.focus, &collectInput.inputStyles.focus)
          updateStyle(update.inputStyles.invalid, &collectInput.inputStyles.invalid)
-         updateStyle(update.inputStyles.requiredAstrisk, &collectInput.inputStyles.invalid)
+         updateStyle(update.inputStyles.requiredAstrisk, &collectInput.inputStyles.requiredAstrisk)
 
          updateStyle(update.labelStyles.base, &collectInput.labelStyles.base)
          updateStyle(update.labelStyles.complete, &collectInput.labelStyles.complete)
@@ -1355,7 +1355,12 @@ extension TextField {
         } else if currentState["isEmpty"] as! Bool || self.actualValue.isEmpty { // Check if empty
             if currentState["isRequired"] as! Bool { // Check if required
                 isRequiredCheckFailed = true // Set the original flag
-                updateInputStyle(collectInput!.inputStyles.empty)
+                // An empty required field is an error state, so it must use the same
+                // error styling (e.g. red underline) as an invalid value. Merchants only
+                // configure `invalid`; `empty` is left unstyled and would fall back to the
+                // base/black border, leaving the underline inconsistent with the red error
+                // message. See ONB-856.
+                updateInputStyle(collectInput!.inputStyles.invalid)
                 errorMessage.alpha = 1.0 // Show error label
             } else {
                 updateInputStyle(collectInput!.inputStyles.complete)

--- a/Payrails/Classes/Public/Views/ApplePayElement.swift
+++ b/Payrails/Classes/Public/Views/ApplePayElement.swift
@@ -58,11 +58,6 @@ public extension Payrails {
                 delegate?.onPaymentButtonClicked(button)
             }
 
-            print("--------------------")
-            print("save instrument: ", self.saveInstrument)
-            Payrails.log("save instrumentsssss: ", self.saveInstrument)
-            print("--------------------")
-
             paymentTask = Task { [weak self] in
                 guard let self = self else { return }
                 do {

--- a/Payrails/Classes/Public/Views/Card/CardForm.swift
+++ b/Payrails/Classes/Public/Views/Card/CardForm.swift
@@ -461,7 +461,16 @@ public extension Payrails {
             guard let session = self.session else {
                 throw PayrailsError.missingData("Session is required for tokenization.")
             }
+            // Single entry point: route through the unified `tokenize` so the card and wallet
+            // paths share one implementation. `Session.tokenize(.card(_:))` calls back into
+            // `encryptCardData()` below (NOT this method), so there is no recursion.
+            return try await session.tokenize(.card(self), options: options)
+        }
 
+        /// Collects the live card fields from the embedded form and encrypts them with the CSE,
+        /// returning the vault ciphertext. Called by `Session.tokenize(.card(_:))`: the form owns
+        /// the PAN and the encryption (the PCI boundary), so this stays on the form, not the session.
+        func encryptCardData() async throws -> String {
             guard self.container != nil else {
                 throw PayrailsError.missingData("Card form container is not available")
             }
@@ -513,8 +522,7 @@ public extension Payrails {
                 securityCode: securityCode
             )
 
-            let encryptedData = try payrailsCSE.encryptCardData(card: payrailsCard)
-            return try await session.tokenize(encryptedData: encryptedData, options: options)
+            return try payrailsCSE.encryptCardData(card: payrailsCard)
         }
 
         private func notifyCollectionFailure(_ error: Error) {

--- a/PayrailsTests/PayrailsTests.swift
+++ b/PayrailsTests/PayrailsTests.swift
@@ -3059,6 +3059,12 @@ final class PayrailsTests: XCTestCase {
 
         handler.paymentAuthorizationViewControllerDidFinish(vc)
 
+        // The terminal status is delivered asynchronously on the main queue, after the Apple Pay
+        // controller finishes dismissing. Drain the main queue before asserting.
+        let delivered = expectation(description: "terminal status delivered")
+        DispatchQueue.main.async { delivered.fulfill() }
+        wait(for: [delivered], timeout: 1.0)
+
         XCTAssertEqual(spy.didFinishCalls.count, 1,
                        "Pre-authorization dismissal must emit exactly one terminal status")
         guard let firstStatus = spy.didFinishCalls.first?.status,

--- a/PayrailsTests/PayrailsTests.swift
+++ b/PayrailsTests/PayrailsTests.swift
@@ -1403,6 +1403,81 @@ final class PayrailsTests: XCTestCase {
         )
     }
 
+    // MARK: - Error-state underline styling (ONB-856)
+
+    func testEmptyRequiredFieldAppliesInvalidUnderlineColor() {
+        // ONB-856 regression: an empty *required* field in its error state must adopt the
+        // `invalid` border color for the underline. Previously it used the (unstyled) `empty`
+        // slot and fell back to the base/black color while still showing a red error message.
+        UIView.setAnimationsEnabled(false)
+        let field = makeErrorStateField(baseColor: .black, invalidColor: .systemRed)
+        flushMainQueue()
+
+        XCTAssertEqual(
+            field.textField.underlineLayer?.strokeColor,
+            UIColor.black.cgColor,
+            "Field should start on the base underline color"
+        )
+
+        // Empty + required, exactly as a submit/blur with no value triggers.
+        field.updateErrorMessage()
+        flushMainQueue()
+
+        XCTAssertEqual(
+            field.textField.underlineLayer?.strokeColor,
+            UIColor.systemRed.cgColor,
+            "Empty required field in error state should use the invalid border color, not base"
+        )
+    }
+
+    func testErrorTriggeredFieldAppliesInvalidUnderlineColor() {
+        // Programmatic error (setError) must also drive the invalid underline color.
+        UIView.setAnimationsEnabled(false)
+        let field = makeErrorStateField(baseColor: .black, invalidColor: .systemRed)
+        flushMainQueue()
+
+        field.setError("Invalid value")
+        flushMainQueue()
+
+        XCTAssertEqual(
+            field.textField.underlineLayer?.strokeColor,
+            UIColor.systemRed.cgColor,
+            "setError should apply the invalid border color to the underline"
+        )
+    }
+
+    private func makeErrorStateField(
+        baseColor: UIColor,
+        invalidColor: UIColor,
+        borderWidth: CGFloat = 1
+    ) -> TextField {
+        let input = CollectElementInput(
+            table: "cards",
+            column: "card_number",
+            inputStyles: Styles(
+                base: Style(borderColor: baseColor, borderWidth: borderWidth),
+                invalid: Style(borderColor: invalidColor)
+            ),
+            labelStyles: Styles(base: Style()),
+            errorTextStyles: Styles(base: Style()),
+            label: "Card number",
+            placeholder: "",
+            type: .CARD_NUMBER
+        )
+        let options = CollectElementOptions(
+            required: true,
+            enableCardIcon: false,
+            enableCopy: false,
+            fieldVariant: .filled
+        )
+        return TextField(
+            input: input,
+            options: options,
+            contextOptions: ContextOptions(env: .DEV),
+            elements: []
+        )
+    }
+
     // MARK: - Composable Field Stretching Tests
 
     func testComposableContainerSingleFieldRowHasTrailingConstraint() throws {

--- a/PayrailsTests/PayrailsTests.swift
+++ b/PayrailsTests/PayrailsTests.swift
@@ -1829,7 +1829,7 @@ final class PayrailsTests: XCTestCase {
             paymentMethod: "card",
             storeInstrument: true,
             futureUsage: "CardOnFile",
-            data: SaveInstrumentBodyData(
+            data: .card(
                 encryptedData: "encrypted-data-xyz",
                 vaultProviderConfigId: "vault-config-abc"
             )
@@ -1846,6 +1846,33 @@ final class PayrailsTests: XCTestCase {
         let dataDict = decoded?["data"] as? [String: Any]
         XCTAssertEqual(dataDict?["encryptedData"] as? String, "encrypted-data-xyz")
         XCTAssertEqual(dataDict?["vaultProviderConfigId"] as? String, "vault-config-abc")
+    }
+
+    /// The Apple Pay (wallet) tokenization body: only `paymentToken` is sent, and the
+    /// card-only keys are omitted entirely — the two shapes are mutually exclusive, so the
+    /// backend must never see a wallet payload carrying empty card fields. Mirrors the card
+    /// case above and locks the wire contract that `SaveInstrumentBodyData.applePay` produces.
+    func testSaveInstrumentBodyEncoding_applePay_emitsWalletShapeOnly() throws {
+        let body = SaveInstrumentBody(
+            holderReference: "holder-ref-123",
+            paymentMethod: "applePay",
+            storeInstrument: true,
+            futureUsage: "CardOnFile",
+            data: .applePay(paymentToken: "wallet-token-xyz")
+        )
+
+        let jsonData = try JSONEncoder().encode(body)
+        let decoded = try JSONSerialization.jsonObject(with: jsonData) as? [String: Any]
+
+        XCTAssertEqual(decoded?["holderReference"] as? String, "holder-ref-123")
+        XCTAssertEqual(decoded?["paymentMethod"] as? String, "applePay")
+        XCTAssertEqual(decoded?["storeInstrument"] as? Bool, true)
+        XCTAssertEqual(decoded?["futureUsage"] as? String, "CardOnFile")
+
+        let dataDict = decoded?["data"] as? [String: Any]
+        XCTAssertEqual(dataDict?["paymentToken"] as? String, "wallet-token-xyz")
+        XCTAssertNil(dataDict?["encryptedData"], "Apple Pay body must omit encryptedData")
+        XCTAssertNil(dataDict?["vaultProviderConfigId"], "Apple Pay body must omit vaultProviderConfigId")
     }
 
     func testSaveInstrumentResponseDecoding() throws {
@@ -3085,9 +3112,12 @@ final class PayrailsTests: XCTestCase {
         DispatchQueue.main.async { delivered.fulfill() }
         wait(for: [delivered], timeout: 1.0)
 
-        XCTAssertEqual(spy.didFailTokenizationCalls.count, 1,
-                       "Pre-authorization dismissal in tokenize mode must report exactly one cancellation")
-        XCTAssertTrue(spy.didFailTokenizationCalls.first is CancellationError,
+        XCTAssertEqual(spy.didFinishTokenizationResults.count, 1,
+                       "Pre-authorization dismissal in tokenize mode must report exactly one terminal result")
+        guard case .failure(let error)? = spy.didFinishTokenizationResults.first else {
+            return XCTFail("Tokenize cancellation must be reported as a .failure result")
+        }
+        XCTAssertTrue(error is CancellationError,
                       "Tokenize cancellation must be reported as a CancellationError")
         XCTAssertTrue(spy.didFinishCalls.isEmpty,
                       "Tokenize mode must not emit a payment terminal status")
@@ -3166,7 +3196,7 @@ final class PayrailsTests: XCTestCase {
 /// satisfy the protocol contract as no-ops.
 private final class SpyPaymentHandlerDelegate: PaymentHandlerDelegate {
     var didFinishCalls: [(type: Payrails.PaymentType, status: PaymentHandlerStatus)] = []
-    var didFailTokenizationCalls: [Error] = []
+    var didFinishTokenizationResults: [Result<SaveInstrumentResponse, Error>] = []
 
     func paymentHandlerDidFinish(
         handler: PaymentHandler,
@@ -3177,8 +3207,11 @@ private final class SpyPaymentHandlerDelegate: PaymentHandlerDelegate {
         didFinishCalls.append((type, status))
     }
 
-    func paymentHandlerDidFailTokenization(handler: PaymentHandler, error: Error) {
-        didFailTokenizationCalls.append(error)
+    func paymentHandlerDidFinishTokenization(
+        handler: PaymentHandler,
+        result: Result<SaveInstrumentResponse, Error>
+    ) {
+        didFinishTokenizationResults.append(result)
     }
 
     func paymentHandlerDidFail(

--- a/PayrailsTests/PayrailsTests.swift
+++ b/PayrailsTests/PayrailsTests.swift
@@ -3074,10 +3074,52 @@ final class PayrailsTests: XCTestCase {
         }
     }
 
+    func testApplePayHandler_DismissalWithoutAuthorize_Tokenize_EmitsCancellation() throws {
+        let spy = SpyPaymentHandlerDelegate()
+        let handler = try makeTestApplePayHandler(delegate: spy, mode: .tokenize)
+        let vc = try makeStubApplePayVC()
+
+        handler.paymentAuthorizationViewControllerDidFinish(vc)
+
+        let delivered = expectation(description: "tokenization cancellation delivered")
+        DispatchQueue.main.async { delivered.fulfill() }
+        wait(for: [delivered], timeout: 1.0)
+
+        XCTAssertEqual(spy.didFailTokenizationCalls.count, 1,
+                       "Pre-authorization dismissal in tokenize mode must report exactly one cancellation")
+        XCTAssertTrue(spy.didFailTokenizationCalls.first is CancellationError,
+                      "Tokenize cancellation must be reported as a CancellationError")
+        XCTAssertTrue(spy.didFinishCalls.isEmpty,
+                      "Tokenize mode must not emit a payment terminal status")
+    }
+
+    // MARK: - OnTokenizeResult mapping (callback API)
+
+    func testOnTokenizeResult_mapsCancellationErrorToCancelled() {
+        guard case .cancelled = OnTokenizeResult(failure: CancellationError()) else {
+            return XCTFail("CancellationError must map to .cancelled")
+        }
+    }
+
+    func testOnTokenizeResult_mapsPayrailsErrorToFailedUnchanged() {
+        guard case .failed(.invalidDataFormat) = OnTokenizeResult(failure: PayrailsError.invalidDataFormat) else {
+            return XCTFail("A PayrailsError must map to .failed with the same case")
+        }
+    }
+
+    func testOnTokenizeResult_wrapsUnknownErrorInFailedUnknown() {
+        let underlying = NSError(domain: "test", code: 42)
+        guard case .failed(.unknown(let wrapped)) = OnTokenizeResult(failure: underlying) else {
+            return XCTFail("A non-PayrailsError must map to .failed(.unknown)")
+        }
+        XCTAssertEqual((wrapped as NSError?)?.code, 42, "The underlying error must be preserved")
+    }
+
     // MARK: - ApplePayHandler test helpers
 
     private func makeTestApplePayHandler(
-        delegate: PaymentHandlerDelegate
+        delegate: PaymentHandlerDelegate,
+        mode: ApplePayHandler.Mode = .payment
     ) throws -> ApplePayHandler {
         let json = """
         {
@@ -3093,7 +3135,7 @@ final class PayrailsTests: XCTestCase {
             PaymentOptions.ApplePayConfig.self,
             from: Data(json.utf8)
         )
-        return ApplePayHandler(config: config, delegate: delegate, saveInstrument: false)
+        return ApplePayHandler(config: config, delegate: delegate, saveInstrument: false, mode: mode)
     }
 
     /// Minimal stub `PKPaymentAuthorizationViewController` for handing to the delegate
@@ -3124,6 +3166,7 @@ final class PayrailsTests: XCTestCase {
 /// satisfy the protocol contract as no-ops.
 private final class SpyPaymentHandlerDelegate: PaymentHandlerDelegate {
     var didFinishCalls: [(type: Payrails.PaymentType, status: PaymentHandlerStatus)] = []
+    var didFailTokenizationCalls: [Error] = []
 
     func paymentHandlerDidFinish(
         handler: PaymentHandler,
@@ -3132,6 +3175,10 @@ private final class SpyPaymentHandlerDelegate: PaymentHandlerDelegate {
         payload: [String: Any]?
     ) {
         didFinishCalls.append((type, status))
+    }
+
+    func paymentHandlerDidFailTokenization(handler: PaymentHandler, error: Error) {
+        didFailTokenizationCalls.append(error)
     }
 
     func paymentHandlerDidFail(

--- a/docs/internal/architecture.md
+++ b/docs/internal/architecture.md
@@ -224,6 +224,34 @@ SDK calls authorize API
 
 The `failure` argument is an `AuthorizationFailure` struct with `code: AuthorizationFailureReason`, `message: String`, and `rawError: Error?`. The four `code` values (raw values match the Web SDK 1:1): `.authorizationError` (issuer declined / 3DS rejected / fraud blocked — `message` is the backend's `errors[0].reason.result` with a generic fallback, never nil), `.authenticationError` (session token rejected, HTTP 401 / 403), `.userCancelled` (user dismissed the 3DS sheet), `.unknownError` (network or SDK error — `rawError` carries the underlying error). The `onSessionExpired` closure (supplied at `createSession` time) fires ONLY on paths that leave the Payrails execution non-terminal (pending) on the backend — i.e. the user abandoned 3DS and the confirmation poll couldn't surface a backend terminal during the grace window. Backend-confirmed terminals (success, authorization-failed, cancel-URL) do NOT trigger it, because those executions are closed cleanly. See [`error-handling.md`](error-handling.md) for the full mapping.
 
+## Apple Pay tokenization flow (happy path)
+
+```mermaid
+sequenceDiagram
+    participant App as Merchant App
+    participant Session as PayrailsSession
+    participant Handler as ApplePayHandler
+    participant Sheet as Apple Pay Sheet
+    participant API as Payrails API
+
+    App->>Session: tokenize(.applePay(presenter:))
+    Session->>Handler: present (Mode.tokenize)
+    Handler->>Sheet: present PKPaymentAuthorizationViewController
+    Sheet-->>Handler: didAuthorizePayment(PKPayment)
+    Handler->>API: POST /instruments (makeTokenizationPaymentToken)
+    API-->>Handler: SaveInstrumentResponse
+    Handler-->>Session: resume continuation(.success)
+    Session-->>App: SaveInstrumentResponse
+```
+
+`ApplePayHandler` runs in one of two modes chosen at construction: `.payment` (authorize) or `.tokenize` (save, no charge). `session.tokenize(.applePay(presenter:))` bridges PassKit's delegate callbacks into `async/await` with a checked continuation — the continuation is stored, the sheet is presented on the main actor, and it is resumed exactly once from the `PaymentHandlerDelegate` methods.
+
+In tokenize mode the resume happens **after** the create-instrument POST returns, so the Apple Pay sheet stays open across the network call and the customer sees a single uninterrupted interaction. The handler serializes the `PKPayment` into the create-instrument shape via `makeTokenizationPaymentToken` — `{ token: { paymentData, paymentMethod, transactionIdentifier }, billingContact?, shippingContact? }`, a different shape from the flattened authorize payload — and the session POSTs it through the shared `saveInstrument` core (`paymentMethod: "applePay"`, `data.paymentToken`), the same core the card path uses. A pre-authorization dismissal is reported as a `CancellationError`, distinct from a failure.
+
+Inside the token, `paymentMethod.type` is mapped from PassKit's numeric `PKPaymentMethodType` to the backend's lowercase strings (`credit`/`debit`/`prepaid`/`store`) so the iOS wallet payload matches the web SDK's.
+
+---
+
 ## 3DS flow (detailed)
 
 ```

--- a/docs/internal/merchant-usage-guide.md
+++ b/docs/internal/merchant-usage-guide.md
@@ -305,6 +305,41 @@ if !session.isApplePayAvailable {
 
 ---
 
+## Tokenization (save without pay)
+
+`session.tokenize` saves an instrument without charging — the two-step counterpart to `executePayment`: tokenize → charge later with `executePayment(withStoredInstrument:)`. It is unified across methods via `TokenizationRequest`, and offers both async and callback overloads. The returned id is `SaveInstrumentResponse.id`.
+
+```swift
+// Apple Pay — async; `self` conforms to PaymentPresenter
+let saved = try await session.tokenize(
+    .applePay(presenter: self),
+    options: TokenizeOptions(storeInstrument: true, futureUsage: .cardOnFile)
+)
+let instrumentId = saved.id
+
+// Card — tokenize the embedded card form (options default to TokenizeOptions())
+let savedCard = try await session.tokenize(.card(cardForm))
+
+// Callback variant (options has a default, so it can be omitted)
+session.tokenize(
+    .applePay(presenter: self),
+    onSuccess: { saved in /* saved.id */ },
+    onFailed:  { error in /* PayrailsError */ },
+    onCancelled: { /* customer dismissed the Apple Pay sheet */ }
+)
+```
+
+Charge a tokenized instrument later by resolving it from the stored instruments and calling `executePayment`:
+
+```swift
+let result = await session.executePayment(
+    withStoredInstrument: storedInstrument,
+    presenter: self
+)
+```
+
+---
+
 ## PayPal
 
 ```swift

--- a/docs/internal/public-api-audit.md
+++ b/docs/internal/public-api-audit.md
@@ -39,7 +39,9 @@ Living document tracking every public symbol in the SDK. Update this whenever a 
 | `Payrails.Session.executePayment(withStoredInstrument:...:onResult:)` | PUBLIC | Stored instrument payment |
 | `Payrails.Session.executePayment(with:...) async` | PUBLIC | Async variant |
 | `Payrails.Session.cancelPayment()` | INTERNAL | Only called by SDK UI components on dispose; merchants using async `executePayment(...)` cancel their own `Task`. Matches Android SDK. |
-| `Payrails.Session.tokenize(encryptedData:options:)` | PUBLIC | Card vaulting without payment |
+| `Payrails.Session.tokenize(_:options:) async` | PUBLIC | Unified tokenize (async). `TokenizationRequest` = `.applePay(presenter:)` / `.card(CardForm)`; returns `SaveInstrumentResponse`. |
+| `Payrails.Session.tokenize(_:options:onSuccess:onFailed:onCancelled:)` | PUBLIC | Callback counterpart of the async tokenize. |
+| `Payrails.Session.tokenize(encryptedData:options:)` | INTERNAL | Shared card-vaulting core; reached via `tokenize(.card(...))`. Not merchant-facing. |
 | `Payrails.Session.deleteInstrument(instrumentId:)` | PUBLIC | Direct instrument deletion |
 | `Payrails.Session.updateInstrument(instrumentId:body:)` | PUBLIC | Direct instrument update |
 | `Payrails.Session.update(_:)` | PUBLIC | Runtime session state mutation |
@@ -228,7 +230,7 @@ Living document tracking every public symbol in the SDK. Update this whenever a 
 |---|---|---|
 | `DeleteInstrumentResponse` | PUBLIC | Returned from `session.deleteInstrument(instrumentId:)` |
 | `UpdateInstrumentResponse` | PUBLIC | Returned from `session.updateInstrument(instrumentId:body:)` |
-| `SaveInstrumentResponse` | PUBLIC | Returned from `CardForm.tokenize(options:)` |
+| `SaveInstrumentResponse` | PUBLIC | Returned from `session.tokenize(_:options:)` and `CardForm.tokenize(options:)` |
 | `UpdateInstrumentBody` | PUBLIC | Body payload for `updateInstrument` |
 
 > **Removed in 1.28.0:** `InstrumentAPIResponse` enum was removed alongside `Payrails.api(_:_:_:)`. Session methods now return their concrete response types directly.
@@ -239,6 +241,7 @@ Living document tracking every public symbol in the SDK. Update this whenever a 
 
 | Symbol | Status | Notes |
 |---|---|---|
+| `Payrails.TokenizationRequest` | PUBLIC | Selects the method to tokenize: `.applePay(presenter:)` / `.card(CardForm)`. Not `Decodable` (holds live runtime objects). |
 | `TokenizeOptions` | PUBLIC | |
 | `FutureUsage` | PUBLIC | `.cardOnFile`, `.subscription`, `.unscheduledCardOnFile` |
 

--- a/docs/public/concepts.md
+++ b/docs/public/concepts.md
@@ -125,6 +125,18 @@ Assign the delegate before adding the element to the window.
 
 ---
 
+## Tokenization
+
+Tokenization saves a payment method as a reusable Payrails **instrument** without charging the customer. It returns a stable instrument `id` that identifies the saved method for later use.
+
+This exists to support a **two-step model**: tokenize first, run the resulting instrument through an external decision — a saved-card list, a subscription setup — and only then, if at all, charge it with `executePayment`. Charging is a separate, deliberate action, never a side effect of tokenizing.
+
+Tokenization is **unified across payment methods**. The same `session.tokenize` call handles Apple Pay (the SDK presents the Apple Pay sheet) and cards (the SDK encrypts the embedded card form), selected by the `TokenizationRequest` case, and both return the same `SaveInstrumentResponse`. Adding a method later does not change how the call is made.
+
+Tokenization is distinct from **pay-and-save**: pay-and-save (the `storeInstrument` toggle on a payment) charges the customer and vaults the method in one step, whereas tokenization vaults without any charge.
+
+---
+
 ## 3D Secure
 
 When a card payment requires a 3DS challenge, the SDK presents an `SFSafariViewController`. Your view controller must conform to `PaymentPresenter` and implement `presentPayment(_:)`:

--- a/docs/public/sdk-api-reference.md
+++ b/docs/public/sdk-api-reference.md
@@ -114,7 +114,7 @@ If the closure is omitted, the SDK logs a warning at init time and cannot recove
 **When to use `query(_:)` vs session methods directly:**
 
 - **`query(_:)`** — stateless reads of session metadata (holder reference, amount, execution ID, API links, payment method config, stored instruments). Single unified accessor returning a `PayrailsQueryResult` enum.
-- **Session methods** — actions and mutations (`executePayment`, `deleteInstrument`, `updateInstrument`, `update`), device-capability checks (`isApplePayAvailable`), or typed reads where merchants prefer concrete return types over an enum (`getPaymentMethodConfig(_:)`).
+- **Session methods** — actions and mutations (`executePayment`, `tokenize`, `deleteInstrument`, `updateInstrument`, `update`), device-capability checks (`isApplePayAvailable`), or typed reads where merchants prefer concrete return types over an enum (`getPaymentMethodConfig(_:)`).
 
 Rule of thumb: **`query(_:)` reads data; session methods do things, check the device, or return typed values.**
 
@@ -155,6 +155,20 @@ public class Payrails.Session {
         withStoredInstrument instrument: StoredInstrument,
         presenter: PaymentPresenter?
     ) async -> OnPayResult
+
+    // Tokenization — save an instrument without paying (async + callback)
+    public func tokenize(
+        _ request: Payrails.TokenizationRequest,
+        options: TokenizeOptions = TokenizeOptions()
+    ) async throws -> SaveInstrumentResponse
+
+    public func tokenize(
+        _ request: Payrails.TokenizationRequest,
+        options: TokenizeOptions = TokenizeOptions(),
+        onSuccess: @escaping (SaveInstrumentResponse) -> Void,
+        onFailed: @escaping (PayrailsError) -> Void,
+        onCancelled: @escaping () -> Void
+    )
 
     // Instrument management
     public func deleteInstrument(instrumentId: String) async throws -> DeleteInstrumentResponse
@@ -529,10 +543,17 @@ public enum PayrailsError: Error, LocalizedError {
 
 ## Tokenization
 
+Saves a payment method as a reusable instrument without charging the customer. `tokenize` is unified across methods: the `TokenizationRequest` case selects which instrument to tokenize and carries what that method needs. Both overloads live on `Payrails.Session` (see [Session](#session)), alongside `executePayment`.
+
 ```swift
+public enum Payrails.TokenizationRequest {
+    case applePay(presenter: PaymentPresenter)  // SDK presents the Apple Pay sheet
+    case card(CardForm)                          // SDK reads + encrypts the embedded card form
+}
+
 public struct TokenizeOptions {
-    public let storeInstrument: Bool
-    public let futureUsage: FutureUsage
+    public let storeInstrument: Bool    // default false
+    public let futureUsage: FutureUsage // default .cardOnFile
 }
 
 public enum FutureUsage: String {
@@ -540,6 +561,26 @@ public enum FutureUsage: String {
     case subscription
     case unscheduledCardOnFile
 }
+
+public struct SaveInstrumentResponse: Decodable {
+    public let id: String             // stable Payrails instrument id
+    public let createdAt: String
+    public let holderId: String
+    public let paymentMethod: String  // e.g. "applePay", "card"
+    public let status: String
+    public let data: InstrumentData
+    public let fingerprint: String?
+    public let futureUsage: String?
+}
+```
+
+```swift
+// Apple Pay — async; `self` conforms to PaymentPresenter
+let response = try await session.tokenize(
+    .applePay(presenter: self),
+    options: TokenizeOptions(storeInstrument: true)
+)
+let instrumentId = response.id
 ```
 
 See [How to Tokenize a Card](how-to-tokenize-card.md).


### PR DESCRIPTION
## Description

### Apple Pay Tokenization — Code Walkthrough (iOS SDK)
Merchant calls `session.tokenize(.applePay(presenter:))` and gets back the saved
instrument. Internally the SDK presents the Apple Pay sheet, captures the token,
POSTs it to the create-instrument endpoint, and resolves the `async` call.



| Step | Symbol | Location | What it does |
|---|---|---|---|
| entry | `tokenize(.applePay(presenter:))` | `PayrailsSession.swift:937` | Merchant's single async entry point; `await` here returns the saved instrument (or throws) |
| suspend | store options + `withCheckedThrowingContinuation` + store continuation | `PayrailsSession.swift:948–950` | Parks the `await` and saves a "resume handle" so a later callback can finish it; stashes the `TokenizeOptions` for the network call |
| present | `Task { @MainActor … presentApplePayTokenizationSheet }` | `PayrailsSession.swift:951` → `210` | Hops to the main thread to start presenting the Apple Pay UI |
| build sheet | `ApplePayHandler(mode: .tokenize)` + `makePayment` | `PayrailsSession.swift:224–233` · `ApplePayHandler.swift:106` | Reads the Apple Pay config from the init response, creates the handler in tokenize mode, builds the `PKPaymentRequest` |
| show | `presenter.presentPayment(controller)` | `ApplePayHandler.swift:127` | Puts the Apple Pay sheet on screen via the merchant's presenter |
| authorize | `didAuthorizePayment` → `didAuthorize = true`, `mode == .tokenize` | `ApplePayHandler.swift:198, 203, 209` | User confirmed (Face ID / side button); marks that auth happened and routes into the tokenize branch |
| serialize | `makeTokenizationPaymentToken(from:)` | `ApplePayHandler.swift:210` (def `48`) | Turns the `PKPayment` into the exact `{ billingContact, shippingContact, token:{…} }` JSON the backend expects |
| hold + request | `delegate.paymentHandlerDidRequestTokenization(paymentToken) { … }` | `ApplePayHandler.swift:221` | Hands the token to the session and keeps the sheet open (spinner) while the network call runs |
| network | `saveInstrument(…)` → `PayrailsAPI.saveInstrument` → POST | `PayrailsSession.swift:464, 472, 975` · `PayrailsAPI.swift:229` | Builds the `applePay` save body and POSTs to `/payment/instruments`, returning the instrument |
| stash + close | set `finishAfterDismissal` → `paymentCompletion(.success/.failure)` | `ApplePayHandler.swift:227, 233–237` | Records *what* to report later, then tells PassKit the outcome so the sheet shows success/failure and begins dismissing |
| dismiss | `didFinish` → `dismiss(controller) { … }` → `controller.dismiss(animated:true) { complete() }` | `ApplePayHandler.swift:177, 180, 321` | Dismisses the sheet with animation and waits for that animation to fully complete before doing anything else |
| resume (post-dismiss) | `finish?(self)` → `paymentHandlerDidFinishTokenization(result:)` | `ApplePayHandler.swift:184–186` · `PayrailsSession.swift:489` | Runs the stashed closure only after dismissal, telling the session the tokenize result — the freeze-fix gate |
| return | `finishApplePayTokenization` → `continuation.resume(with:)` | `PayrailsSession.swift:237–238` | Resumes the parked `await`, so `tokenize()` returns the instrument (or throws); clears state |
| cancel | `didFinish` + `!didAuthorize` → `paymentHandlerDidFailTokenization(CancellationError())` | `ApplePayHandler.swift:190–191` · `PayrailsSession.swift:498` | User dismissed the sheet without authorizing → resumes the `await` by throwing `CancellationError` |
| card twin | `tokenize(encryptedData:)` → shared `saveInstrument` core | `PayrailsSession.swift:961, 975` | Card path (from `cardForm.tokenize()`) reuses the same POST core — one network path for all methods |
## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Release
- [ ] ⏩ Revert

## Screenshots/Recordings

<!-- Visual changes require screenshots -->

## Added tests?

- [x] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?

- [ ] 📜 README.md
- [ ] 🗂️ Internal documentation
- [ ] 📓 Public Documentation (docs.payrails.com)
- [ ] 🙅 no documentation needed

## [optional] Are there any post-release tasks we need to perform?
