### PR TITLE
ONB-856: Fix card form underline error state

### DIFF
--- a/Payrails/Classes/Public/Vault/elements/TextField.swift
+++ b/Payrails/Classes/Public/Vault/elements/TextField.swift
@@ -285,7 +285,7 @@ public class TextField: SkyflowElement, Element, BaseElement {
          updateStyle(update.inputStyles.empty, &collectInput.inputStyles.empty)
          updateStyle(update.inputStyles.focus, &collectInput.inputStyles.focus)
          updateStyle(update.inputStyles.invalid, &collectInput.inputStyles.invalid)
-         updateStyle(update.inputStyles.requiredAstrisk, &collectInput.inputStyles.invalid)
+         updateStyle(update.inputStyles.requiredAstrisk, &collectInput.inputStyles.requiredAstrisk)
 
          updateStyle(update.labelStyles.base, &collectInput.labelStyles.base)
          updateStyle(update.labelStyles.complete, &collectInput.labelStyles.complete)
@@ -1355,7 +1355,12 @@ extension TextField {
         } else if currentState["isEmpty"] as! Bool || self.actualValue.isEmpty { // Check if empty
             if currentState["isRequired"] as! Bool { // Check if required
                 isRequiredCheckFailed = true // Set the original flag
-                updateInputStyle(collectInput!.inputStyles.empty)
+                // An empty required field is an error state, so it must use the same
+                // error styling (e.g. red underline) as an invalid value. Merchants only
+                // configure `invalid`; `empty` is left unstyled and would fall back to the
+                // base/black border, leaving the underline inconsistent with the red error
+                // message. See ONB-856.
+                updateInputStyle(collectInput!.inputStyles.invalid)
                 errorMessage.alpha = 1.0 // Show error label
             } else {
                 updateInputStyle(collectInput!.inputStyles.complete)

--- a/PayrailsTests/PayrailsTests.swift
+++ b/PayrailsTests/PayrailsTests.swift
@@ -1403,6 +1403,81 @@ final class PayrailsTests: XCTestCase {
         )
     }
 
+    // MARK: - Error-state underline styling (ONB-856)
+
+    func testEmptyRequiredFieldAppliesInvalidUnderlineColor() {
+        // ONB-856 regression: an empty *required* field in its error state must adopt the
+        // `invalid` border color for the underline. Previously it used the (unstyled) `empty`
+        // slot and fell back to the base/black color while still showing a red error message.
+        UIView.setAnimationsEnabled(false)
+        let field = makeErrorStateField(baseColor: .black, invalidColor: .systemRed)
+        flushMainQueue()
+
+        XCTAssertEqual(
+            field.textField.underlineLayer?.strokeColor,
+            UIColor.black.cgColor,
+            "Field should start on the base underline color"
+        )
+
+        // Empty + required, exactly as a submit/blur with no value triggers.
+        field.updateErrorMessage()
+        flushMainQueue()
+
+        XCTAssertEqual(
+            field.textField.underlineLayer?.strokeColor,
+            UIColor.systemRed.cgColor,
+            "Empty required field in error state should use the invalid border color, not base"
+        )
+    }
+
+    func testErrorTriggeredFieldAppliesInvalidUnderlineColor() {
+        // Programmatic error (setError) must also drive the invalid underline color.
+        UIView.setAnimationsEnabled(false)
+        let field = makeErrorStateField(baseColor: .black, invalidColor: .systemRed)
+        flushMainQueue()
+
+        field.setError("Invalid value")
+        flushMainQueue()
+
+        XCTAssertEqual(
+            field.textField.underlineLayer?.strokeColor,
+            UIColor.systemRed.cgColor,
+            "setError should apply the invalid border color to the underline"
+        )
+    }
+
+    private func makeErrorStateField(
+        baseColor: UIColor,
+        invalidColor: UIColor,
+        borderWidth: CGFloat = 1
+    ) -> TextField {
+        let input = CollectElementInput(
+            table: "cards",
+            column: "card_number",
+            inputStyles: Styles(
+                base: Style(borderColor: baseColor, borderWidth: borderWidth),
+                invalid: Style(borderColor: invalidColor)
+            ),
+            labelStyles: Styles(base: Style()),
+            errorTextStyles: Styles(base: Style()),
+            label: "Card number",
+            placeholder: "",
+            type: .CARD_NUMBER
+        )
+        let options = CollectElementOptions(
+            required: true,
+            enableCardIcon: false,
+            enableCopy: false,
+            fieldVariant: .filled
+        )
+        return TextField(
+            input: input,
+            options: options,
+            contextOptions: ContextOptions(env: .DEV),
+            elements: []
+        )
+    }
+
     // MARK: - Composable Field Stretching Tests
 
     func testComposableContainerSingleFieldRowHasTrailingConstraint() throws {


### PR DESCRIPTION
## Description

Fixes a card-form bug where the **underline element did not adopt the error styling** in the error state — neither colour nor width changed — even though the error message label turned red. Focused and valid states styled the underline correctly; the error state did not.

- **ONB-856** [Card form does not apply error styling to the underline element (both previous and new versions)](https://linear.app/payrails/issue/ONB-856) — *High*

**Root cause.** The error styling itself was never broken. In `TextField.updateErrorMessage()`, a genuinely **invalid value** (`!isValid`) and a programmatic `setError(...)` both correctly resolve to `inputStyles.invalid` → red underline. What was wrong is that an **empty + required** field in its error state resolved to `inputStyles.empty` instead:

```swift
} else if currentState["isEmpty"] ... {
    if currentState["isRequired"] {
        updateInputStyle(collectInput!.inputStyles.empty)   // ← was empty
        errorMessage.alpha = 1.0                            //    but shows the red error message
```

Merchants only ever configure the error look through `invalid` (there is no merchant-facing `empty` knob; the SDK default `empty` is unstyled). So an empty required field fell back to the **base** border colour (black) while still displaying a red error message — the visual inconsistency QA reported. Because this lives in the shared state-resolution logic rather than the underline renderer, it reproduced in both the outlined (border) and filled (underline) variants — i.e. "both previous and new versions".

## How it's fixed

Single commit, two changes in `Payrails/Classes/Public/Vault/elements/TextField.swift`:

| Change | What |
|---|---|
| **The fix** | The empty-required error branch now applies `inputStyles.invalid` instead of `inputStyles.empty`, so the underline/border matches the (already-red) error message across **every** error path: empty-required, invalid value, and programmatic `setError`. |
| **Collateral** | Fixed a copy-paste bug in `update(update:)` where `requiredAstrisk` was being written into `inputStyles.invalid`; it now writes to `inputStyles.requiredAstrisk`. Latent today (source is empty), corrected for correctness. |

Behavioural note: empty-required fields now look identical to invalid-value fields (same `invalid` style). Since merchants only expose `invalid`, treating "empty-required" as an error is the intended behaviour — flagging it explicitly for reviewer awareness.

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [x] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Release
- [ ] ⏩ Revert

## Screenshots/Recordings

Verified in the bootstrap-ios Full Integration Demo (`.filled` variant).

| State | Before | After |
|---|---|---|
| Empty + required | red error text, **black** underline ❌ | red error text, **red** underline ✅ |
| Invalid value (non-empty) | red ✅ | red ✅ (unchanged) |
| Focused | blue ✅ | blue ✅ (unchanged) |
| Valid / untouched fields | base colour ✅ | base colour ✅ (no regression) |

Also confirmed the underline honours arbitrary merchant config (not a hardcoded colour) by driving the demo with custom `invalid` colours (orange, purple) and a custom `base` colour (teal) — the underline rendered exactly the configured colour in each state.

## Added tests?

- [x] 👍 yes

Added to `PayrailsTests/PayrailsTests.swift`:

- `testEmptyRequiredFieldAppliesInvalidUnderlineColor` — asserts an empty required field in error state uses the `invalid` border colour, not the base colour. Confirmed it **fails on the pre-fix code** (asserts black ≠ red) and passes on the fix, so it genuinely guards the regression.
- `testErrorTriggeredFieldAppliesInvalidUnderlineColor` — asserts `setError(...)` drives the invalid underline colour.
- `makeErrorStateField(...)` helper, mirroring the existing `makeFieldWithVariant`.

Full suite: **157 tests, 0 failures** (includes the integrated ONB-768 tokenize tests).

## Added to documentation?

- [x] 🙅 no documentation needed

## ⚠️ Breaking changes

None. Behavioural correction only — no public API surface changes.

## Notes for reviewer

- **Base branch:** `ONB-768-tokenize-functionality`. This branch was rebased onto the latest `origin/ONB-768-tokenize-functionality` (the stale local "poc" commits were dropped in favour of the remote's polished tokenize commits), so it is now exactly one ONB-856 commit on top of that base. The PR head will need a force-push to reflect the rebase.
- The `invalid`-value and `setError` error paths were already correct; the only functional change is the empty-required branch.
- Minor known gap (not addressed here, covered in practice by blur/`resignFirstResponder`): `ComposableContainer.collect()` calls `updateErrorMessage()` for empty-required fields but not for non-empty `!isValid` fields at submit time. Happy to tighten in a follow-up if desired.

## Files changed

- `Payrails/Classes/Public/Vault/elements/TextField.swift`
- `PayrailsTests/PayrailsTests.swift`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
